### PR TITLE
Fix precedence of code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @nemo794
-* @gmgunter
+* @nemo794 @gmgunter


### PR DESCRIPTION
Later lines in a CODEOWNERS file take precedence over earlier lines. Previously, we put the two code owners on separate lines with identical wildcard patterns. This caused only the second code owner to be requested for review. This update puts both code owners on the same line, indicating co-ownership.