### PR TITLE
Bugfix: Correct error messages for poorly-formed `calibrationInformation` metadata

### DIFF
--- a/src/nisarqa/__init__.py
+++ b/src/nisarqa/__init__.py
@@ -125,7 +125,7 @@ from .utils.file_verification.dataset_inclusion_rules import *
 from .utils.file_verification.verify import *
 from .utils.file_verification.xml_check import *
 from .utils.file_verification.xml_parser import *
-from .utils.metadata_cube_checks import *
+from .utils.metadata_checks import *
 
 # keep individual products in their own namespace
 from .products import (

--- a/src/nisarqa/parameters/nisar_params.py
+++ b/src/nisarqa/parameters/nisar_params.py
@@ -1101,7 +1101,7 @@ class ValidationGroupParamGroup(YamlParamGroup):
         # VALIDATE INPUTS
         if not isinstance(self.metadata_luts_fail_if_all_nan, bool):
             raise TypeError(
-                f"`{self.=}`, must be bool."
+                f"`{self.metadata_luts_fail_if_all_nan=}`, must be bool."
             )
 
     @staticmethod

--- a/src/nisarqa/parameters/nisar_params.py
+++ b/src/nisarqa/parameters/nisar_params.py
@@ -1076,7 +1076,7 @@ class ValidationGroupParamGroup(YamlParamGroup):
 
     Parameters
     ----------
-    metadata_fail_if_all_nan : str
+    metadata_luts_fail_if_all_nan : str
         True to raise an exception if one or more metadata datasets contain
         all non-finite (e.g. Nan, +/- Inf) values, or if one or more
         z-dimension height layers in a 3D dataset has all non-finite values.
@@ -1084,11 +1084,11 @@ class ValidationGroupParamGroup(YamlParamGroup):
         Defaults to True.
     """
 
-    metadata_fail_if_all_nan: bool = field(
+    metadata_luts_fail_if_all_nan: bool = field(
         default=True,
         metadata={
             "yaml_attrs": YamlAttrs(
-                name="metadata_fail_if_all_nan",
+                name="metadata_luts_fail_if_all_nan",
                 descr="""True to raise an exception if one or more metadata datasets
                 contain all non-finite (e.g. Nan, +/- Inf) values, or if one or more
                 z-dimension height layers in a 3D dataset has all non-finite values.
@@ -1099,9 +1099,9 @@ class ValidationGroupParamGroup(YamlParamGroup):
 
     def __post_init__(self):
         # VALIDATE INPUTS
-        if not isinstance(self.metadata_fail_if_all_nan, bool):
+        if not isinstance(self.metadata_luts_fail_if_all_nan, bool):
             raise TypeError(
-                f"`{self.metadata_fail_if_all_nan=}`, must be bool."
+                f"`{self.=}`, must be bool."
             )
 
     @staticmethod

--- a/src/nisarqa/parameters/nisar_params.py
+++ b/src/nisarqa/parameters/nisar_params.py
@@ -1076,22 +1076,22 @@ class ValidationGroupParamGroup(YamlParamGroup):
 
     Parameters
     ----------
-    metadata_cubes_fail_if_all_nan : str
-        True to raise an exception if one or more metadata cubes contains
+    metadata_fail_if_all_nan : str
+        True to raise an exception if one or more metadata datasets contain
         all non-finite (e.g. Nan, +/- Inf) values, or if one or more
-        z-dimension height layers in a 3D cube has all non-finite values.
+        z-dimension height layers in a 3D dataset has all non-finite values.
         False to quiet the exception (although it will still be logged).
         Defaults to True.
     """
 
-    metadata_cubes_fail_if_all_nan: bool = field(
+    metadata_fail_if_all_nan: bool = field(
         default=True,
         metadata={
             "yaml_attrs": YamlAttrs(
-                name="metadata_cubes_fail_if_all_nan",
-                descr="""True to raise an exception if one or more metadata cubes contains
-                all non-finite (e.g. Nan, +/- Inf) values, or if one or more
-                z-dimension height layers in a 3D cube has all non-finite values.
+                name="metadata_fail_if_all_nan",
+                descr="""True to raise an exception if one or more metadata datasets
+                contain all non-finite (e.g. Nan, +/- Inf) values, or if one or more
+                z-dimension height layers in a 3D dataset has all non-finite values.
                 False to quiet the exception (although it will still be logged).""",
             )
         },
@@ -1099,9 +1099,9 @@ class ValidationGroupParamGroup(YamlParamGroup):
 
     def __post_init__(self):
         # VALIDATE INPUTS
-        if not isinstance(self.metadata_cubes_fail_if_all_nan, bool):
+        if not isinstance(self.metadata_fail_if_all_nan, bool):
             raise TypeError(
-                f"`{self.metadata_cubes_fail_if_all_nan=}`, must be bool."
+                f"`{self.metadata_fail_if_all_nan=}`, must be bool."
             )
 
     @staticmethod

--- a/src/nisarqa/parameters/nisar_params.py
+++ b/src/nisarqa/parameters/nisar_params.py
@@ -1077,9 +1077,9 @@ class ValidationGroupParamGroup(YamlParamGroup):
     Parameters
     ----------
     metadata_luts_fail_if_all_nan : str
-        True to raise an exception if one or more metadata datasets contain
+        True to raise an exception if one or more metadata LUTs contain
         all non-finite (e.g. Nan, +/- Inf) values, or if one or more
-        z-dimension height layers in a 3D dataset has all non-finite values.
+        z-dimension height layers in a 3D LUT has all non-finite values.
         False to quiet the exception (although it will still be logged).
         Defaults to True.
     """
@@ -1089,9 +1089,9 @@ class ValidationGroupParamGroup(YamlParamGroup):
         metadata={
             "yaml_attrs": YamlAttrs(
                 name="metadata_luts_fail_if_all_nan",
-                descr="""True to raise an exception if one or more metadata datasets
+                descr="""True to raise an exception if one or more metadata LUTs
                 contain all non-finite (e.g. Nan, +/- Inf) values, or if one or more
-                z-dimension height layers in a 3D dataset has all non-finite values.
+                z-dimension height layers in a 3D LUT has all non-finite values.
                 False to quiet the exception (although it will still be logged).""",
             )
         },

--- a/src/nisarqa/products/gcov.py
+++ b/src/nisarqa/products/gcov.py
@@ -83,12 +83,12 @@ def verify_gcov(
 
         nisarqa.verify_metadata_cubes(
             product=product,
-            fail_if_all_nan=root_params.validation.metadata_fail_if_all_nan,
+            fail_if_all_nan=root_params.validation.metadata_luts_fail_if_all_nan,
         )
 
         nisarqa.verify_calibration_metadata(
             product=product,
-            fail_if_all_nan=root_params.validation.metadata_fail_if_all_nan,
+            fail_if_all_nan=root_params.validation.metadata_luts_fail_if_all_nan,
         )
 
         nisarqa.dataset_sanity_checks(product=product)

--- a/src/nisarqa/products/gcov.py
+++ b/src/nisarqa/products/gcov.py
@@ -83,7 +83,12 @@ def verify_gcov(
 
         nisarqa.verify_metadata_cubes(
             product=product,
-            fail_if_all_nan=root_params.validation.metadata_cubes_fail_if_all_nan,
+            fail_if_all_nan=root_params.validation.metadata_fail_if_all_nan,
+        )
+
+        nisarqa.verify_calibration_metadata(
+            product=product,
+            fail_if_all_nan=root_params.validation.metadata_fail_if_all_nan,
         )
 
         nisarqa.dataset_sanity_checks(product=product)

--- a/src/nisarqa/products/gcov.py
+++ b/src/nisarqa/products/gcov.py
@@ -86,7 +86,7 @@ def verify_gcov(
             fail_if_all_nan=root_params.validation.metadata_luts_fail_if_all_nan,
         )
 
-        nisarqa.verify_calibration_metadata(
+        nisarqa.verify_calibration_metadata_luts(
             product=product,
             fail_if_all_nan=root_params.validation.metadata_luts_fail_if_all_nan,
         )

--- a/src/nisarqa/products/gslc.py
+++ b/src/nisarqa/products/gslc.py
@@ -85,7 +85,12 @@ def verify_gslc(
 
         nisarqa.verify_metadata_cubes(
             product=product,
-            fail_if_all_nan=root_params.validation.metadata_cubes_fail_if_all_nan,
+            fail_if_all_nan=root_params.validation.metadata_fail_if_all_nan,
+        )
+
+        nisarqa.verify_calibration_metadata(
+            product=product,
+            fail_if_all_nan=root_params.validation.metadata_fail_if_all_nan,
         )
 
         nisarqa.dataset_sanity_checks(product=product)

--- a/src/nisarqa/products/gslc.py
+++ b/src/nisarqa/products/gslc.py
@@ -88,7 +88,7 @@ def verify_gslc(
             fail_if_all_nan=root_params.validation.metadata_luts_fail_if_all_nan,
         )
 
-        nisarqa.verify_calibration_metadata(
+        nisarqa.verify_calibration_metadata_luts(
             product=product,
             fail_if_all_nan=root_params.validation.metadata_luts_fail_if_all_nan,
         )

--- a/src/nisarqa/products/gslc.py
+++ b/src/nisarqa/products/gslc.py
@@ -85,12 +85,12 @@ def verify_gslc(
 
         nisarqa.verify_metadata_cubes(
             product=product,
-            fail_if_all_nan=root_params.validation.metadata_fail_if_all_nan,
+            fail_if_all_nan=root_params.validation.metadata_luts_fail_if_all_nan,
         )
 
         nisarqa.verify_calibration_metadata(
             product=product,
-            fail_if_all_nan=root_params.validation.metadata_fail_if_all_nan,
+            fail_if_all_nan=root_params.validation.metadata_luts_fail_if_all_nan,
         )
 
         nisarqa.dataset_sanity_checks(product=product)

--- a/src/nisarqa/products/igram.py
+++ b/src/nisarqa/products/igram.py
@@ -118,7 +118,7 @@ def verify_igram(
 
         nisarqa.verify_metadata_cubes(
             product=product,
-            fail_if_all_nan=root_params.validation.metadata_cubes_fail_if_all_nan,
+            fail_if_all_nan=root_params.validation.metadata_fail_if_all_nan,
         )
 
         nisarqa.dataset_sanity_checks(product=product)

--- a/src/nisarqa/products/igram.py
+++ b/src/nisarqa/products/igram.py
@@ -118,7 +118,7 @@ def verify_igram(
 
         nisarqa.verify_metadata_cubes(
             product=product,
-            fail_if_all_nan=root_params.validation.metadata_fail_if_all_nan,
+            fail_if_all_nan=root_params.validation.metadata_luts_fail_if_all_nan,
         )
 
         nisarqa.dataset_sanity_checks(product=product)

--- a/src/nisarqa/products/offsets.py
+++ b/src/nisarqa/products/offsets.py
@@ -111,7 +111,7 @@ def verify_offset(
 
         nisarqa.verify_metadata_cubes(
             product=product,
-            fail_if_all_nan=root_params.validation.metadata_cubes_fail_if_all_nan,
+            fail_if_all_nan=root_params.validation.metadata_fail_if_all_nan,
         )
 
         nisarqa.dataset_sanity_checks(product=product)

--- a/src/nisarqa/products/offsets.py
+++ b/src/nisarqa/products/offsets.py
@@ -111,7 +111,7 @@ def verify_offset(
 
         nisarqa.verify_metadata_cubes(
             product=product,
-            fail_if_all_nan=root_params.validation.metadata_fail_if_all_nan,
+            fail_if_all_nan=root_params.validation.metadata_luts_fail_if_all_nan,
         )
 
         nisarqa.dataset_sanity_checks(product=product)

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -938,7 +938,8 @@ class NisarProduct(ABC):
 
                 n_dim = np.ndim(ds_arr)
                 if n_dim in (0, 1):
-                    # scalar and 1D datasets are not LUTs. Skip.
+                    # Scalar and 1D datasets in this group are coordinate dimensions
+                    # and georeferencing info -- not metadata LUTs. Skip them here.
                     pass
                 elif n_dim != 3:
                     raise ValueError(
@@ -1884,7 +1885,8 @@ class NonInsarProduct(NisarProduct):
 
                 n_dim = np.ndim(ds_arr)
                 if n_dim in (0, 1):
-                    # scalar and 1D datasets are not LUTs. Skip.
+                    # Scalar and 1D datasets in this group are coordinate dimensions
+                    # and georeferencing info -- not metadata LUTs. Skip them here.
                     pass
                 elif n_dim != 2:
                     raise ValueError(
@@ -1925,7 +1927,8 @@ class NonInsarProduct(NisarProduct):
 
                 n_dim = np.ndim(ds_arr)
                 if n_dim in (0, 1):
-                    # scalar and 1D datasets are not LUTs. Skip.
+                    # Scalar and 1D datasets in this group are coordinate dimensions
+                    # and georeferencing info -- not metadata LUTs. Skip them here.
                     pass
                 elif n_dim != 2:
                     raise ValueError(
@@ -2596,7 +2599,8 @@ class SLC(NonInsarProduct):
 
                 n_dim = np.ndim(ds_arr)
                 if n_dim in (0, 1):
-                    # scalar and 1D datasets are not LUTs. Skip.
+                    # Scalar and 1D datasets in this group are coordinate dimensions
+                    # and georeferencing info -- not metadata LUTs. Skip them here.
                     pass
                 elif n_dim != 2:
                     raise ValueError(

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -1153,7 +1153,7 @@ class NisarProduct(ABC):
         ds_arr: h5py.Dataset,
     ) -> nisarqa.MetadataLUTT:
         """
-        Construct a MetadataLUT for the given 1D, 2D, or 3D dataset.
+        Construct a MetadataLUT for the given 1D, 2D, or 3D LUT.
 
         Parameters
         ----------
@@ -1899,7 +1899,7 @@ class NonInsarProduct(NisarProduct):
         self, freq: str
     ) -> Iterator[nisarqa.MetadataLUT2D]:
         """
-        Generator for all elevation antenna pattern metadata datasets.
+        Generator for all elevation antenna pattern metadata LUTs.
 
         Yields
         ------

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -943,8 +943,8 @@ class NisarProduct(ABC):
                 elif n_dim != 3:
                     raise ValueError(
                         f"The coordinate grid metadata group should only"
-                        f" contain 1D or 3D Datasets. Dataset contains {n_dim}"
-                        f" dimensions: {ds_path}"
+                        " should only contain scalar, 1D, or 3D Datasets."
+                        f" Dataset contains {n_dim} dimensions: {ds_path}"
                     )
                 else:
                     yield self._build_metadata_lut(f=f, ds_arr=ds_arr)
@@ -1889,8 +1889,8 @@ class NonInsarProduct(NisarProduct):
                 elif n_dim != 2:
                     raise ValueError(
                         "The `noiseEquivalentBackscatter` metadata group"
-                        " should only contain 1D or 2D Datasets. Dataset"
-                        f" contains {n_dim} dimensions: {ds_path}"
+                        " should only contain scalar, 1D, or 2D Datasets."
+                        f" Dataset contains {n_dim} dimensions: {ds_path}"
                     )
                 else:
                     yield self._build_metadata_lut(f=f, ds_arr=ds_arr)
@@ -1930,8 +1930,8 @@ class NonInsarProduct(NisarProduct):
                 elif n_dim != 2:
                     raise ValueError(
                         f"The elevationAntennaPattern metadata group should"
-                        f" only contain 1D or 2D Datasets. Dataset contains"
-                        f" {n_dim} dimensions: {ds_path}"
+                        " should only contain scalar, 1D, or 2D Datasets."
+                        f" Dataset contains {n_dim} dimensions: {ds_path}"
                     )
                 else:
                     yield self._build_metadata_lut(f=f, ds_arr=ds_arr)
@@ -2600,9 +2600,9 @@ class SLC(NonInsarProduct):
                     pass
                 elif n_dim != 2:
                     raise ValueError(
-                        f"The geometry metadata group should only contain 1D"
-                        f" or 2D Datasets. Dataset contains {n_dim}"
-                        f" dimensions: {ds_path}"
+                        f"The geometry metadata group should only contain"
+                        " scalar, 1D, or 2D Datasets."
+                        f" Dataset contains {n_dim} dimensions: {ds_path}"
                     )
                 else:
                     yield self._build_metadata_lut(f=f, ds_arr=ds_arr)

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -938,8 +938,9 @@ class NisarProduct(ABC):
 
                 n_dim = np.ndim(ds_arr)
                 if n_dim in (0, 1):
-                    # Scalar and 1D datasets in this group are coordinate dimensions
-                    # and georeferencing info -- not metadata LUTs. Skip them here.
+                    # Scalar and 1D Datasets in this group are coordinate
+                    # dimensions and georeferencing info -- not metadata LUTs.
+                    # Skip.
                     pass
                 elif n_dim != 3:
                     raise ValueError(
@@ -1885,8 +1886,9 @@ class NonInsarProduct(NisarProduct):
 
                 n_dim = np.ndim(ds_arr)
                 if n_dim in (0, 1):
-                    # Scalar and 1D datasets in this group are coordinate dimensions
-                    # and georeferencing info -- not metadata LUTs. Skip them here.
+                    # Scalar and 1D Datasets in this group are coordinate
+                    # dimensions and georeferencing info -- not metadata LUTs.
+                    # Skip.
                     pass
                 elif n_dim != 2:
                     raise ValueError(
@@ -1927,8 +1929,9 @@ class NonInsarProduct(NisarProduct):
 
                 n_dim = np.ndim(ds_arr)
                 if n_dim in (0, 1):
-                    # Scalar and 1D datasets in this group are coordinate dimensions
-                    # and georeferencing info -- not metadata LUTs. Skip them here.
+                    # Scalar and 1D Datasets in this group are coordinate
+                    # dimensions and georeferencing info -- not metadata LUTs.
+                    # Skip.
                     pass
                 elif n_dim != 2:
                     raise ValueError(
@@ -2599,8 +2602,9 @@ class SLC(NonInsarProduct):
 
                 n_dim = np.ndim(ds_arr)
                 if n_dim in (0, 1):
-                    # Scalar and 1D datasets in this group are coordinate dimensions
-                    # and georeferencing info -- not metadata LUTs. Skip them here.
+                    # Scalar and 1D Datasets in this group are coordinate
+                    # dimensions and georeferencing info -- not metadata LUTs.
+                    # Skip.
                     pass
                 elif n_dim != 2:
                     raise ValueError(

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -938,7 +938,7 @@ class NisarProduct(ABC):
 
                 n_dim = np.ndim(ds_arr)
                 if n_dim in (0, 1):
-                    # scalar and 1D datasets are not metadata cubes. Skip 'em.
+                    # scalar and 1D datasets are not LUTs. Skip.
                     pass
                 elif n_dim != 3:
                     raise ValueError(
@@ -1884,7 +1884,7 @@ class NonInsarProduct(NisarProduct):
 
                 n_dim = np.ndim(ds_arr)
                 if n_dim in (0, 1):
-                    # scalar and 1D datasets are not metadata LUTs. Skip.
+                    # scalar and 1D datasets are not LUTs. Skip.
                     pass
                 elif n_dim != 2:
                     raise ValueError(
@@ -1925,7 +1925,7 @@ class NonInsarProduct(NisarProduct):
 
                 n_dim = np.ndim(ds_arr)
                 if n_dim in (0, 1):
-                    # scalar and 1D datasets are not metadata datasets. Skip.
+                    # scalar and 1D datasets are not LUTs. Skip.
                     pass
                 elif n_dim != 2:
                     raise ValueError(
@@ -2596,7 +2596,7 @@ class SLC(NonInsarProduct):
 
                 n_dim = np.ndim(ds_arr)
                 if n_dim in (0, 1):
-                    # scalar and 1D datasets are not metadata LUTs. Skip.
+                    # scalar and 1D datasets are not LUTs. Skip.
                     pass
                 elif n_dim != 2:
                     raise ValueError(

--- a/src/nisarqa/products/rslc.py
+++ b/src/nisarqa/products/rslc.py
@@ -99,7 +99,12 @@ def verify_rslc(
 
         nisarqa.verify_metadata_cubes(
             product=product,
-            fail_if_all_nan=root_params.validation.metadata_cubes_fail_if_all_nan,
+            fail_if_all_nan=root_params.validation.metadata_fail_if_all_nan,
+        )
+
+        nisarqa.verify_calibration_metadata(
+            product=product,
+            fail_if_all_nan=root_params.validation.metadata_fail_if_all_nan,
         )
 
         nisarqa.dataset_sanity_checks(product=product)

--- a/src/nisarqa/products/rslc.py
+++ b/src/nisarqa/products/rslc.py
@@ -102,7 +102,7 @@ def verify_rslc(
             fail_if_all_nan=root_params.validation.metadata_luts_fail_if_all_nan,
         )
 
-        nisarqa.verify_calibration_metadata(
+        nisarqa.verify_calibration_metadata_luts(
             product=product,
             fail_if_all_nan=root_params.validation.metadata_luts_fail_if_all_nan,
         )

--- a/src/nisarqa/products/rslc.py
+++ b/src/nisarqa/products/rslc.py
@@ -99,12 +99,12 @@ def verify_rslc(
 
         nisarqa.verify_metadata_cubes(
             product=product,
-            fail_if_all_nan=root_params.validation.metadata_fail_if_all_nan,
+            fail_if_all_nan=root_params.validation.metadata_luts_fail_if_all_nan,
         )
 
         nisarqa.verify_calibration_metadata(
             product=product,
-            fail_if_all_nan=root_params.validation.metadata_fail_if_all_nan,
+            fail_if_all_nan=root_params.validation.metadata_luts_fail_if_all_nan,
         )
 
         nisarqa.dataset_sanity_checks(product=product)

--- a/src/nisarqa/utils/metadata_checks.py
+++ b/src/nisarqa/utils/metadata_checks.py
@@ -169,7 +169,7 @@ def verify_metadata_cubes(
     """
     Verify the input product's coordinate grid metadata cube LUTs are valid.
 
-    Coordinate grid metadata cubes are the 3D datasets in the input product's
+    Coordinate grid metadata cubes are the 3D LUTs in the input product's
     coordinate grid (e.g. `geolocationGrid` or `radarGrid`) metadata group.
 
     Parameters
@@ -179,7 +179,7 @@ def verify_metadata_cubes(
     fail_if_all_nan : bool, optional
         True to raise an exception if one of the metadata cubes contains
         all non-finite (e.g. Nan, +/- Inf) values, or if one of the
-        z-dimension height layers in a 3D dataset has all non-finite values.
+        z-dimension height layers in a 3D LUT has all non-finite values.
         False to quiet the exception, although it will still be logged.
         Defaults to True.
 
@@ -274,18 +274,14 @@ def verify_calibration_metadata_luts(
 
     # Check calibration metadata LUTs in metadata Group
     for freq in product.freqs:
-        calib_datasets = chain(
+        calib_luts = chain(
             product.metadata_neb_luts(freq),
             product.metadata_elevation_antenna_pat_luts(freq),
         )
         if isinstance(product, nisarqa.SLC):
-            calib_datasets = chain(
-                calib_datasets, product.metadata_geometry_luts()
-            )
+            calib_luts = chain(calib_luts, product.metadata_geometry_luts())
         if isinstance(product, nisarqa.RSLC):
-            calib_datasets = chain(
-                calib_datasets, product.metadata_crosstalk_luts()
-            )
+            calib_luts = chain(calib_luts, product.metadata_crosstalk_luts())
 
         try:
             # Note: During the __post_init__ of constructing each metadata LUT,
@@ -293,7 +289,7 @@ def verify_calibration_metadata_luts(
             # there are corresponding datasets with x coordinates and
             # y coordinates of the correct length. If these elements are
             # missing, exceptions will get thrown.
-            for ds in calib_datasets:
+            for ds in calib_luts:
                 has_finite &= _lut_has_finite_pixels(ds)
                 passes &= has_finite
                 passes &= _lut_is_not_all_zeros(ds)

--- a/src/nisarqa/utils/metadata_checks.py
+++ b/src/nisarqa/utils/metadata_checks.py
@@ -14,21 +14,21 @@ objects_to_skip = nisarqa.get_all(name=__name__)
 
 
 @dataclass
-class MetadataDataset1D:
+class MetadataLUT1D:
     """
-    1D metadata dataset.
+    1D metadata LUT.
 
     Parameters
     ----------
     data : array_like
-        Metadata dataset with shape (X,). Can be a numpy.ndarray, h5py.Dataset,
-        etc. The dataset will be coerced to and stored as a NumPy array.
+        Metadata LUT with shape (X,). Can be a numpy.ndarray, h5py.Dataset,
+        etc. The LUT will be coerced to and stored as a NumPy array.
     name : str
-        Name for this Dataset. If source data is from an HDF5 file, suggest
+        Name for this MetadataLUT. If source data is from an HDF5 file, suggest
         using the full path to the Dataset for `name`.
     x_coord_vector : array_like
         1D vector with shape (X,) containing the coordinate values for the
-        x axis of the dataset.
+        x axis of the LUT.
         For L1 products, this is the `slantRange` corresponding to `data`.
         For L2 products, this is the `xCoordinates` corresponding to `data`.
     """
@@ -39,7 +39,7 @@ class MetadataDataset1D:
 
     def __post_init__(self):
 
-        # Metadata datasets are, by design, very small in size. So, coerce these
+        # Metadata LUTs are, by design, very small in size. So, coerce these
         # input ArrayLike objects to NumPy arrays during init.
         # Otherwise, they may be repeatedly converted to (temporary) NumPy
         # arrays as we pass them to NumPy functions, matplotlib, etc.
@@ -55,31 +55,31 @@ class MetadataDataset1D:
 
     @property
     def shape(self) -> tuple[int, ...]:
-        """Shape of the metadata dataset."""
+        """Shape of the metadata LUT."""
         return self.data.shape
 
 
 @dataclass
-class MetadataDataset2D(MetadataDataset1D):
+class MetadataLUT2D(MetadataLUT1D):
     """
-    2D metadata dataset.
+    2D metadata LUT.
 
     Parameters
     ----------
     data : array_like
-        Metadata dataset with shape (Y, X). Can be a numpy.ndarray, h5py.Dataset,
-        etc. The dataset will be coerced to and stored as a NumPy array.
+        Metadata LUT with shape (Y, X). Can be a numpy.ndarray, h5py.Dataset,
+        etc. The LUT will be coerced to and stored as a NumPy array.
     name : str
-        Name for this Dataset. If data is from an HDF5 file, suggest using
+        Name for this LUT. If data is from an HDF5 file, suggest using
         the full path to the Dataset for `name`.
     x_coord_vector : array_like
         1D vector with shape (X,) containing the coordinate values for the
-        x axis of the dataset.
+        x axis of the LUT.
         For L1 products, this is the `slantRange` corresponding to `data`.
         For L2 products, this is the `xCoordinates` corresponding to `data`.
     y_coord_vector : array_like
         1D vector with shape (Y,) containing the coordinate values for the
-        y axis of the dataset.
+        y axis of the LUT.
         For L1 products, this is the `zeroDopplerTime` corresponding to `data`.
         For L2 products, this is the `yCoordinates` corresponding to `data`.
     """
@@ -94,42 +94,42 @@ class MetadataDataset2D(MetadataDataset1D):
 
         if self.shape[-2] != len(self.y_coord_vector):
             raise ValueError(
-                f"Dataset {self.name} has y dimension {self.shape[-2]},"
+                f"LUT {self.name} has y dimension {self.shape[-2]},"
                 f" which should match the length of the cooresponding y-axis"
                 f" coordinate vector which is {len(self.y_coord_vector)}."
             )
 
 
 @dataclass
-class MetadataDataset3D(MetadataDataset2D):
+class MetadataLUT3D(MetadataLUT2D):
     """
-    3D metadata dataset.
+    3D metadata LUT.
 
     Parameters
     ----------
     data : array_like
-        Metadata dataset with shape (Z, Y, X). Can be a numpy.ndarray,
-        h5py.Dataset, etc. The dataset will be coerced to and stored as
+        Metadata LUT with shape (Z, Y, X). Can be a numpy.ndarray,
+        h5py.Dataset, etc. The LUT will be coerced to and stored as
         a NumPy array.
     name : str
-        Name for this Dataset. If data is from an HDF5 file, suggest using
+        Name for this LUT. If data is from an HDF5 file, suggest using
         the full path to the Dataset for `name`. If `name` ends with 'Baseline',
-        the dataset will be assumed to be a parallel baseline or perpendicular
-        baseline dataset, which may have a z-dimension of 2 regardless of the
+        the LUT will be assumed to be a parallel baseline or perpendicular
+        baseline LUT, which may have a z-dimension of 2 regardless of the
         size of `z_coord_vector`.
     x_coord_vector : array_like
         1D vector with shape (X,) containing the coordinate values for the
-        x axis of the dataset.
+        x axis of the LUT.
         For L1 products, this is the `slantRange` corresponding to `data`.
         For L2 products, this is the `xCoordinates` corresponding to `data`.
     y_coord_vector : array_like
         1D vector with shape (Y,) containing the coordinate values for the
-        y axis of the dataset.
+        y axis of the LUT.
         For L1 products, this is the `zeroDopplerTime` corresponding to `data`.
         For L2 products, this is the `yCoordinates` corresponding to `data`.
     z_coord_vector : array_like
         1D vector with shape (Z,) containing the coordinate values for the
-        z axis of the dataset.
+        z axis of the LUT.
         For NISAR, this is `heightAboveEllipsoid` corresponding to `data`.
     """
 
@@ -143,11 +143,11 @@ class MetadataDataset3D(MetadataDataset2D):
         len_z = len(self.z_coord_vector)
         if self.shape[-3] != len_z:
             if self.name.endswith("Baseline"):
-                # `parallelBaseline` and `perpendicularBaseline` Datasets
+                # `parallelBaseline` and `perpendicularBaseline` LUTs
                 # either have a height of 2 or the length of the z coordinates
                 if self.shape[-3] != 2:
                     raise nisarqa.InvalidRasterError(
-                        f"Dataset {self.name} has z dimension {self.shape[-3]},"
+                        f"LUT {self.name} has z dimension {self.shape[-3]},"
                         " which should either be 2 or match the length of the"
                         " cooresponding z-axis coordinate vector which is"
                         f" {len_z}."
@@ -156,7 +156,7 @@ class MetadataDataset3D(MetadataDataset2D):
                     len_z = 2
             else:
                 raise nisarqa.InvalidRasterError(
-                    f"Dataset {self.name} has z dimension {self.shape[-3]},"
+                    f"LUT {self.name} has z dimension {self.shape[-3]},"
                     f" which should match the length of the cooresponding"
                     f" z-axis coordinate vector which is {len_z}."
                 )
@@ -166,7 +166,7 @@ def verify_metadata_cubes(
     product: nisarqa.NisarProduct, fail_if_all_nan: bool = True
 ) -> None:
     """
-    Verify the input product's coordinate grid metadata cubes are valid.
+    Verify the input product's coordinate grid metadata cube LUTs are valid.
 
     Coordinate grid metadata cubes are the 3D datasets in the input product's
     coordinate grid (e.g. `geolocationGrid` or `radarGrid`) metadata group.
@@ -185,27 +185,27 @@ def verify_metadata_cubes(
     Raises
     ------
     nisarqa.InvalidRasterError
-        If `fail_if_all_nan` is True and if one or more metadata datasets
+        If `fail_if_all_nan` is True and if one or more metadata LUTs
         contains all non-finite (e.g. Nan, +/- Inf) values, or if one of
-        the z-dimension height layers in a 3D dataset has all non-finite values.
+        the z-dimension height layers in a 3D LUT has all non-finite values.
     """
 
-    # Flag indicating if metadata datasets pass all verification checks; used
+    # Flag indicating if metadata LUTs pass all verification checks; used
     # for Summary CSV reporting
     passes = True
     has_finite = True
 
-    # Check metadata datasets in metadata Group
+    # Check metadata LUTs in metadata Group
     try:
-        # Note: During the __post_init__ of constructing each metadata dataset,
+        # Note: During the __post_init__ of constructing each metadata LUT,
         # several validation checks are performed, including ensuring that
         # there are corresponding datasets with x coordinates and y coordinates
         # of the correct length. If these elements are missing, exceptions
         # will get thrown.
         for cube in product.coordinate_grid_metadata_cubes():
-            has_finite &= _dataset_has_finite_pixels(cube)
+            has_finite &= _lut_has_finite_pixels(cube)
             passes &= has_finite
-            passes &= _dataset_is_not_all_zeros(cube)
+            passes &= _lut_is_not_all_zeros(cube)
             passes &= _check_gdal(product=product, ds=cube)
 
     except (nisarqa.DatasetNotFoundError, ValueError):
@@ -225,18 +225,18 @@ def verify_metadata_cubes(
         )
 
 
-def verify_calibration_metadata(
+def verify_calibration_metadata_luts(
     product: nisarqa.NonInsarProduct, fail_if_all_nan: bool = True
 ) -> None:
     """
-    Verify if the input product's calibration metadata datasets are valid.
+    Verify if the input product's calibration metadata LUTs are valid.
 
     Parameters
     ----------
     product : nisarqa.NonInsarProduct
         Instance of the input product.
     fail_if_all_nan : bool, optional
-        True to raise an exception if one of the metadata datasets contains
+        True to raise an exception if one of the metadata LUTs contains
         all non-finite (e.g. Nan, +/- Inf) values.
         False to quiet the exception, although it will still be logged.
         Defaults to True.
@@ -244,18 +244,18 @@ def verify_calibration_metadata(
     Raises
     ------
     nisarqa.InvalidRasterError
-        If `fail_if_all_nan` is True and if one or more metadata datasets
+        If `fail_if_all_nan` is True and if one or more metadata LUTs
         contains all non-finite (e.g. Nan, +/- Inf) values.
     """
     log = nisarqa.get_logger()
-    # Flag indicating if metadata datasets pass all verification checks; used
+    # Flag indicating if metadata LUTs pass all verification checks; used
     # for Summary CSV reporting
     passes = True
     has_finite = True
 
-    # Check metadata datasets in metadata Group
+    # Check calibration metadata LUTs in metadata Group
     try:
-        # Note: During the __post_init__ of constructing each metadata dataset,
+        # Note: During the __post_init__ of constructing each metadata LUT,
         # several validation checks are performed, including ensuring that
         # there are corresponding datasets with x coordinates and y coordinates
         # of the correct length. If these elements are missing, exceptions
@@ -267,44 +267,44 @@ def verify_calibration_metadata(
             if spec < nisarqa.Version(1, 1, 0):
                 break
 
-            for ds in product.metadata_neb_datasets(freq):
-                has_finite &= _dataset_has_finite_pixels(ds)
+            for ds in product.metadata_neb_luts(freq):
+                has_finite &= _lut_has_finite_pixels(ds)
                 passes &= has_finite
-                passes &= _dataset_is_not_all_zeros(ds)
+                passes &= _lut_is_not_all_zeros(ds)
                 passes &= _check_gdal(product=product, ds=ds)
 
-            for ds in product.metadata_elevation_antenna_pat_datasets(freq):
-                has_finite &= _dataset_has_finite_pixels(ds)
+            for ds in product.metadata_elevation_antenna_pat_luts(freq):
+                has_finite &= _lut_has_finite_pixels(ds)
                 passes &= has_finite
-                passes &= _dataset_is_not_all_zeros(ds)
+                passes &= _lut_is_not_all_zeros(ds)
                 passes &= _check_gdal(product=product, ds=ds)
 
             if isinstance(product, nisarqa.SLC):
-                for ds in product.metadata_geometry_datasets():
-                    has_finite &= _dataset_has_finite_pixels(ds)
+                for ds in product.metadata_geometry_luts():
+                    has_finite &= _lut_has_finite_pixels(ds)
                     passes &= has_finite
-                    passes &= _dataset_is_not_all_zeros(ds)
+                    passes &= _lut_is_not_all_zeros(ds)
                     passes &= _check_gdal(product=product, ds=ds)
 
             if isinstance(product, nisarqa.RSLC):
-                for ds in product.metadata_crosstalk_datasets():
-                    has_finite &= _dataset_has_finite_pixels(ds)
+                for ds in product.metadata_crosstalk_luts():
+                    has_finite &= _lut_has_finite_pixels(ds)
                     passes &= has_finite
-                    passes &= _dataset_is_not_all_zeros(ds)
+                    passes &= _lut_is_not_all_zeros(ds)
                 summary_notes = ""
             else:
                 # GSLC and GCOV products contain the `crosstalk` Group with
-                # datasets copied directly from the input RSLC product,
+                # LUTs copied directly from the input RSLC product,
                 # but these are neither geocoded nor georeferenced.
                 # This means that that there is no corresponding
                 # e.g. `xCoordinates` datasets, so it is not possible to
-                # build/test a MetadataDataset.
+                # build/test a MetadataLUT.
                 log.warning(
                     "Verification of calibration information `crosstalk`"
-                    " metadata datasets was skipped by QA. Please update QA"
+                    " metadata LUTs was skipped by QA. Please update QA"
                     " code once these datasets become georeferenced."
                 )
-                summary_notes = "`crosstalk` datasets skipped."
+                summary_notes = "`crosstalk` LUTs skipped."
 
     except (nisarqa.DatasetNotFoundError, ValueError):
         log.error(traceback.format_exc())
@@ -318,7 +318,7 @@ def verify_calibration_metadata(
 
     if fail_if_all_nan and (not has_finite):
         raise nisarqa.InvalidRasterError(
-            "One or more calibration metadata datasets contains all non-finite"
+            "One or more calibration metadata LUTs contains all non-finite"
             " (e.g. NaN, +/- Inf) values. See log file"
             " for details and names of the failing dataset(s)."
         )
@@ -326,34 +326,32 @@ def verify_calibration_metadata(
 
 def _check_gdal(
     product: nisarqa.NisarProduct,
-    ds: nisarqa.MetadataDataset2D | nisarqa.MetadataDataset3D,
+    ds: nisarqa.MetadataLUT2D | nisarqa.MetadataLUT3D,
 ) -> bool:
     """
-    Check if product and member dataset are either L1, or L2 and GDAL-friendly.
+    Check if product and member LUT are either L1, or L2 and GDAL-friendly.
 
-    Always returns `True` if the dataset is not geocoded and/or not an
-    h5py.Dataset.
+    Always returns `True` if the LUT is not geocoded and/or not an h5py.Dataset.
 
     Parameters
     ----------
     product : nisarqa.NisarProduct
         Instance of the input product. If product is not geocoded (e.g. it
         is an L1 product), the function will always return True.
-    ds : nisarqa.MetadataDataset2D or nisarqa.MetadataDataset3D
-        Metadata Dataset to be checked. If `ds.data` is not an h5py.Dataset,
+    ds : nisarqa.MetadataLUT2D or nisarqa.MetadataLUT3D
+        Metadata LUT to be checked. If `ds.data` LUT is not an h5py.Dataset,
         the function will always return True.
 
     Returns
     -------
     passes : bool
-        True if the dataset contains at least one finite pixel (meaning, it is
-        considered a valid dataset), or if input product is not geocoded,
+        True if the LUT contains at least one finite pixel (meaning, it is
+        considered a valid LUT), or if input product is not geocoded,
          or if `ds` is not an h5py.Dataset.
-        False if the given metadata dataset contains all non-finite (e.g. NaN,
+        False if the given metadata LUT contains all non-finite (e.g. NaN,
         +/- Inf) values.
-        Or, if the dataset is 3D, and if any of the z-dimension
-        height layers is all non-finite, it is also considered malformed and we
-        return False.
+        Or, if the LUT is 3D, and if any of the z-dimension height layers
+        is all non-finite, it is also considered malformed and we return False.
     """
     if product.is_geocoded and isinstance(ds.data, h5py.Dataset):
         return is_gdal_friendly(
@@ -438,41 +436,40 @@ def is_gdal_friendly(input_filepath: str, ds_path: str) -> bool:
         return False
 
 
-def _dataset_has_finite_pixels(ds: nisarqa.MetadataDatasetT) -> bool:
+def _lut_has_finite_pixels(ds: nisarqa.MetadataLUTT) -> bool:
     """
-    Return False if dataset contains all non-finite values; True otherwise.
+    Return False if LUT contains all non-finite values; True otherwise.
 
     Parameters
     ----------
-    ds : nisarqa.MetadataDatasetT
-        Metadata Dataset to be checked.
+    ds : nisarqa.MetadataLUTT
+        Metadata LUT to be checked.
 
     Returns
     -------
     passes : bool
-        True if the dataset contains at least one finite pixel. (Meaning, it is
-        considered a valid dataset.)
-        False if the given metadata dataset contains all non-finite (e.g. NaN,
+        True if the LUT contains at least one finite pixel. (Meaning, it is
+        considered a valid LUT.)
+        False if the given metadata LUT contains all non-finite (e.g. NaN,
         +/- Inf) values.
-        Or, if the dataset is 3D, and if any of the z-dimension
-        height layers is all non-finite, it is also considered malformed and we
-        return False.
+        Or, if the LUT is 3D, and if any of the z-dimension height layers
+        is all non-finite, it is also considered malformed and we return False.
     """
     log = nisarqa.get_logger()
 
     if not np.isfinite(ds.data).any():
         log.error(
-            f"Metadata dataset {ds.name} contains all non-finite"
+            f"Metadata LUT {ds.name} contains all non-finite"
             " (e.g. NaN) values."
         )
         return False
 
-    # For 3-D datasets, check each z-layer individually for all-NaN values.
-    if isinstance(ds, MetadataDataset3D):
+    # For 3-D LUTs, check each z-layer individually for all-NaN values.
+    if isinstance(ds, MetadataLUT3D):
         for z in range(ds.shape[0]):
             if not np.isfinite(ds.data[z, :, :]).any():
                 log.error(
-                    f"Metadata dataset {ds.name} z-axis layer number {z}"
+                    f"Metadata LUT {ds.name} z-axis layer number {z}"
                     " contains all non-finite (e.g. NaN) values."
                 )
                 return False
@@ -480,25 +477,24 @@ def _dataset_has_finite_pixels(ds: nisarqa.MetadataDatasetT) -> bool:
     return True
 
 
-def _dataset_is_not_all_zeros(ds: nisarqa.MetadataDatasetT) -> bool:
+def _lut_is_not_all_zeros(ds: nisarqa.MetadataLUTT) -> bool:
     """
-    Return False if metadata dataset contains all near-zeros; True otherwise.
+    Return False if metadata LUT contains all near-zeros; True otherwise.
 
     Parameters
     ----------
-    ds : nisarqa.MetadataDatasetT
-        Metadata Dataset to be checked.
+    ds : nisarqa.MetadataLUTT
+        Metadata LUT to be checked.
 
     Returns
     -------
     Passes : bool
-        True if the dataset contains at least one non-near-zero pixel. (Meaning,
-        it is considered a valid dataset.)
-        False if the given metadata dataset contain all near-zero ( <1e-12 )
-        values, it is likely a malformed Dataset.
-        Or, if the dataset is 3D, and if any of the z-dimension
-        height layers is all near-zero, it is also considered malformed and we
-        return False.
+        True if the LUT contains at least one non-near-zero pixel. (Meaning,
+        it is considered a valid LUT.)
+        False if the given metadata LUT contain all near-zero ( <1e-12 )
+        values, it is likely a malformed LUT.
+        Or, if the LUT is 3D, and if any of the z-dimension height layers
+        is all near-zero, it is also considered malformed and we return False.
     """
     log = nisarqa.get_logger()
 
@@ -508,14 +504,13 @@ def _dataset_is_not_all_zeros(ds: nisarqa.MetadataDatasetT) -> bool:
         # So, issue obnoxious warnings for now.
         # TODO - refine this check during CalVal once real data comes back.
         msg = (
-            f"Metadata dataset {ds.name} contains all near-zero"
-            " (<1e-12) values."
+            f"Metadata LUT {ds.name} contains all near-zero" " (<1e-12) values."
         )
         log.warning(msg)
         return False
 
-    # For 3-D datasets, check each z-layer individually for all near-zero values.
-    if isinstance(ds, MetadataDataset3D):
+    # For 3-D LUTs, check each z-layer individually for all near-zero values.
+    if isinstance(ds, MetadataLUT3D):
         for z in range(ds.shape[0]):
             if np.all(np.abs(ds.data[z, :, :]) < 1e-12):
                 # This check is likely to raise a lot of failures.
@@ -523,7 +518,7 @@ def _dataset_is_not_all_zeros(ds: nisarqa.MetadataDatasetT) -> bool:
                 # So, issue obnoxious warnings for now.
                 # TODO - refine this check during CalVal once real data comes back.
                 msg = (
-                    f"Metadata dataset {ds.name} z-axis layer number {z}"
+                    f"Metadata LUT {ds.name} z-axis layer number {z}"
                     " contains all near-zero (<1e-12) values."
                 )
                 log.warning(msg)

--- a/src/nisarqa/utils/metadata_checks.py
+++ b/src/nisarqa/utils/metadata_checks.py
@@ -289,11 +289,11 @@ def verify_calibration_metadata_luts(
             # there are corresponding datasets with x coordinates and
             # y coordinates of the correct length. If these elements are
             # missing, exceptions will get thrown.
-            for ds in calib_luts:
-                has_finite &= _lut_has_finite_pixels(ds)
-                passes &= has_finite
-                passes &= _lut_is_not_all_zeros(ds)
-                passes &= _check_gdal(product=product, ds=ds)
+            for lut in calib_luts:
+                has_finite &= _lut_has_finite_pixels(lut)
+                passes &= _lut_is_not_all_zeros(lut)
+                passes &= _check_gdal(product=product, ds=lut)
+            passes &= has_finite
 
         except (nisarqa.DatasetNotFoundError, ValueError):
             log.error(traceback.format_exc())

--- a/src/nisarqa/utils/metadata_checks.py
+++ b/src/nisarqa/utils/metadata_checks.py
@@ -208,7 +208,7 @@ def verify_metadata_cubes(
             passes &= _dataset_is_not_all_zeros(cube)
             passes &= _check_gdal(product=product, ds=cube)
 
-    except (nisarqa.DatasetNotFoundError, ValueError) as e:
+    except (nisarqa.DatasetNotFoundError, ValueError):
         nisarqa.get_logger().error(traceback.format_exc())
         passes = False
 
@@ -220,7 +220,7 @@ def verify_metadata_cubes(
         raise nisarqa.InvalidRasterError(
             "One or more metadata cubes contains all non-finite"
             " (e.g. NaN, +/- Inf) values or one of the z-dimension height"
-            " layers in a 3D cube has all non-finite values. See log file"
+            " layers in a cube has all non-finite values. See log file"
             " for details and names of the failing dataset(s)."
         )
 
@@ -233,12 +233,11 @@ def verify_calibration_metadata(
 
     Parameters
     ----------
-    product : nisarqa.NisarNonInsarProductProduct
+    product : nisarqa.NonInsarProduct
         Instance of the input product.
     fail_if_all_nan : bool, optional
         True to raise an exception if one of the metadata datasets contains
-        all non-finite (e.g. Nan, +/- Inf) values, or if one of the
-        z-dimension height layers in a 3D dataset has all non-finite values.
+        all non-finite (e.g. Nan, +/- Inf) values.
         False to quiet the exception, although it will still be logged.
         Defaults to True.
 
@@ -246,8 +245,7 @@ def verify_calibration_metadata(
     ------
     nisarqa.InvalidRasterError
         If `fail_if_all_nan` is True and if one or more metadata datasets
-        contains all non-finite (e.g. Nan, +/- Inf) values, or if one of
-        the z-dimension height layers in a 3D dataset has all non-finite values.
+        contains all non-finite (e.g. Nan, +/- Inf) values.
     """
     log = nisarqa.get_logger()
     # Flag indicating if metadata datasets pass all verification checks; used
@@ -272,7 +270,6 @@ def verify_calibration_metadata(
             for ds in product.metadata_neb_datasets(freq):
                 has_finite &= _dataset_has_finite_pixels(ds)
                 passes &= has_finite
-                passes &= _dataset_has_finite_pixels(ds)
                 passes &= _dataset_is_not_all_zeros(ds)
                 passes &= _check_gdal(product=product, ds=ds)
 
@@ -309,7 +306,7 @@ def verify_calibration_metadata(
                 )
                 summary_notes = "`crosstalk` datasets skipped."
 
-    except (nisarqa.DatasetNotFoundError, ValueError) as e:
+    except (nisarqa.DatasetNotFoundError, ValueError):
         log.error(traceback.format_exc())
         passes = False
 
@@ -322,8 +319,7 @@ def verify_calibration_metadata(
     if fail_if_all_nan and (not has_finite):
         raise nisarqa.InvalidRasterError(
             "One or more calibration metadata datasets contains all non-finite"
-            " (e.g. NaN, +/- Inf) values or one of the z-dimension height"
-            " layers in a 3D dataset has all non-finite values. See log file"
+            " (e.g. NaN, +/- Inf) values. See log file"
             " for details and names of the failing dataset(s)."
         )
 
@@ -335,16 +331,16 @@ def _check_gdal(
     """
     Check if the dataset is GDAL-friendly.
 
-    Function is no-op if the dataset is not geocoded and/or not an h5py.Dataset.
+    Always returns `True` if the dataset is not geocoded and/or not an h5py.Dataset.
 
     Parameters
     ----------
     product : nisarqa.NisarProduct
         Instance of the input product. If product is not geocoded (e.g. it
-        is an L1 product), `passes` will always return as True.
+        is an L1 product), the function will always return True.
     ds : nisarqa.MetadataDataset2D or nisarqa.MetadataDataset3D
         Metadata Dataset to be checked. If `ds.data` is not an h5py.Dataset,
-        `passes` will always return as True.
+        the function will always return True.
 
     Returns
     -------

--- a/src/nisarqa/utils/metadata_checks.py
+++ b/src/nisarqa/utils/metadata_checks.py
@@ -248,6 +248,24 @@ def verify_calibration_metadata_luts(
         contains all non-finite (e.g. Nan, +/- Inf) values.
     """
     log = nisarqa.get_logger()
+    summary = nisarqa.get_summary()
+
+    # Very old test datasets do not necessarily have these calibration
+    # test datasets, and/or they are formatted differently.
+    # Since these are old and unsupported test datasets, ok to skip checks.
+    spec = nisarqa.Version.from_string(product.product_spec_version)
+    if spec < nisarqa.Version(1, 1, 0):
+        msg = (
+            "Input product has an unsupported product specification version."
+            " Verification checks of calibration information metadata skipped."
+        )
+        log.warning(msg)
+        summary.check_calibration_metadata(
+            result="WARN",
+            notes=msg,
+        )
+        return
+
     # Flag indicating if metadata LUTs pass all verification checks; used
     # for Summary CSV reporting
     passes = True
@@ -260,12 +278,7 @@ def verify_calibration_metadata_luts(
         # there are corresponding datasets with x coordinates and y coordinates
         # of the correct length. If these elements are missing, exceptions
         # will get thrown.
-        spec = nisarqa.Version.from_string(product.product_spec_version)
-
         for freq in product.freqs:
-
-            if spec < nisarqa.Version(1, 1, 0):
-                break
 
             for ds in product.metadata_neb_luts(freq):
                 has_finite &= _lut_has_finite_pixels(ds)

--- a/src/nisarqa/utils/metadata_checks.py
+++ b/src/nisarqa/utils/metadata_checks.py
@@ -167,7 +167,7 @@ def verify_metadata_cubes(
     product: nisarqa.NisarProduct, fail_if_all_nan: bool = True
 ) -> None:
     """
-    Verify the input product's coordinate grid metadata cube LUTs are valid.
+    Verify the input product's coordinate grid metadata cubes are valid.
 
     Coordinate grid metadata cubes are the 3D LUTs in the input product's
     coordinate grid (e.g. `geolocationGrid` or `radarGrid`) metadata group.
@@ -252,7 +252,7 @@ def verify_calibration_metadata_luts(
     summary = nisarqa.get_summary()
 
     # Very old test datasets do not necessarily have these calibration
-    # test datasets, and/or they are formatted differently.
+    # datasets, or they are stored with a different layout.
     # Since these are old and unsupported test datasets, ok to skip checks.
     spec = nisarqa.Version.from_string(product.product_spec_version)
     if spec < nisarqa.Version(1, 1, 0):
@@ -317,7 +317,6 @@ def verify_calibration_metadata_luts(
         )
         summary_notes = "`crosstalk` LUTs skipped."
 
-    summary = nisarqa.get_summary()
     summary.check_calibration_metadata(
         result="PASS" if passes else "FAIL", notes=summary_notes
     )

--- a/src/nisarqa/utils/metadata_checks.py
+++ b/src/nisarqa/utils/metadata_checks.py
@@ -315,7 +315,8 @@ def verify_calibration_metadata_luts(
         log.warning(
             "Verification of calibration information `crosstalk`"
             " metadata LUTs was skipped by QA. Please update QA"
-            " code once these datasets become georeferenced."
+            " code once coordinate datasets are added"
+            " to the input product's `crosstalk` group."
         )
         summary_notes = "`crosstalk` LUTs skipped."
 

--- a/src/nisarqa/utils/metadata_checks.py
+++ b/src/nisarqa/utils/metadata_checks.py
@@ -329,9 +329,10 @@ def _check_gdal(
     ds: nisarqa.MetadataDataset2D | nisarqa.MetadataDataset3D,
 ) -> bool:
     """
-    Check if the dataset is GDAL-friendly.
+    Check if product and member dataset are either L1, or L2 and GDAL-friendly.
 
-    Always returns `True` if the dataset is not geocoded and/or not an h5py.Dataset.
+    Always returns `True` if the dataset is not geocoded and/or not an
+    h5py.Dataset.
 
     Parameters
     ----------
@@ -349,7 +350,7 @@ def _check_gdal(
         considered a valid dataset), or if input product is not geocoded,
          or if `ds` is not an h5py.Dataset.
         False if the given metadata dataset contains all non-finite (e.g. NaN,
-        +/- Inf) values, it is likely a mal-formed Dataset.
+        +/- Inf) values.
         Or, if the dataset is 3D, and if any of the z-dimension
         height layers is all non-finite, it is also considered malformed and we
         return False.
@@ -452,7 +453,7 @@ def _dataset_has_finite_pixels(ds: nisarqa.MetadataDatasetT) -> bool:
         True if the dataset contains at least one finite pixel. (Meaning, it is
         considered a valid dataset.)
         False if the given metadata dataset contains all non-finite (e.g. NaN,
-        +/- Inf) values, it is likely a mal-formed Dataset.
+        +/- Inf) values.
         Or, if the dataset is 3D, and if any of the z-dimension
         height layers is all non-finite, it is also considered malformed and we
         return False.

--- a/src/nisarqa/utils/summary_csv.py
+++ b/src/nisarqa/utils/summary_csv.py
@@ -410,9 +410,9 @@ class _SummaryCSV:
         )
 
     def check_calibration_metadata(self, result: str, notes: str = "") -> None:
-        """Check: 'Calibration information datasets are valid?'"""
+        """Check: 'Calibration information LUTs are valid?'"""
         self.check(
-            description="Calibration information datasets are valid?",
+            description="Calibration information LUTs are valid?",
             result=result,
             notes=notes,
         )

--- a/src/nisarqa/utils/summary_csv.py
+++ b/src/nisarqa/utils/summary_csv.py
@@ -185,20 +185,20 @@ class _SummaryCSV:
 
     def _validate_result(self, result: str) -> str:
         """
-        Validate that `result` is either 'PASS' or 'FAIL'.
+        Validate that `result` is either "PASS", "FAIL", or "WARN".
 
         Parameters
         ----------
         result : str
-            Either 'PASS' or 'FAIL'.
+            Either "PASS", "FAIL", or "WARN".
 
         Raises
         ------
         ValueError
-            If `result` is neither 'PASS' nor 'FAIL'.
+            If `result` is neither "PASS", "FAIL", nor "WARN"..
         """
         self._validate_string(result)
-        if result not in ("PASS", "FAIL"):
+        if result not in ("PASS", "FAIL", "WARN"):
             raise ValueError(f"`{result=}`, must be either 'PASS' or 'FAIL'.")
 
     def _validate_description(self, description: str) -> str:
@@ -319,7 +319,7 @@ class _SummaryCSV:
             Example 1: "Able to open NISAR input file?"
             Example 2: "Percentage of invalid pixels under threshold?"
         result : str
-            The result of the check. Must be one of: "PASS" or "FAIL"
+            The result of the check. Must be one of: "PASS", "FAIL", "WARN".
         threshold : str, optional
             If a threshold value was used to determine the outcome of the
             PASS/FAIL check, note that value here. Defaults to the empty

--- a/src/nisarqa/utils/summary_csv.py
+++ b/src/nisarqa/utils/summary_csv.py
@@ -403,10 +403,18 @@ class _SummaryCSV:
         )
 
     def check_metadata_cubes(self, result: str) -> None:
-        """Check: 'Metadata cubes are valid?'"""
+        """Check: 'Coordinate grid metadata cubes are valid?'"""
         self.check(
-            description="Metadata cubes are valid?",
+            description="Coordinate grid metadata cubes are valid?",
             result=result,
+        )
+
+    def check_calibration_metadata(self, result: str, notes: str = "") -> None:
+        """Check: 'Calibration information datasets are valid?'"""
+        self.check(
+            description="Calibration information datasets are valid?",
+            result=result,
+            notes=notes,
         )
 
     def check_identification_group(self, result: str) -> None:

--- a/src/nisarqa/utils/typing.py
+++ b/src/nisarqa/utils/typing.py
@@ -5,6 +5,7 @@ __all__ = [
     "RunConfigScalar",
     "RunConfigList",
     "RunConfigDict",
+    "MetadataDatasetT",
 ]
 
 from collections.abc import Mapping, Sequence
@@ -19,3 +20,5 @@ RunConfigDict = Mapping[
 ]
 
 RootParamGroupT = TypeVar("RootParamGroupT", bound="RootParamGroup")
+
+MetadataDatasetT = TypeVar("MetadataDataset", bound="MetadataDataset1D")

--- a/src/nisarqa/utils/typing.py
+++ b/src/nisarqa/utils/typing.py
@@ -5,7 +5,7 @@ __all__ = [
     "RunConfigScalar",
     "RunConfigList",
     "RunConfigDict",
-    "MetadataDatasetT",
+    "MetadataLUTT",
 ]
 
 from collections.abc import Mapping, Sequence
@@ -21,4 +21,4 @@ RunConfigDict = Mapping[
 
 RootParamGroupT = TypeVar("RootParamGroupT", bound="RootParamGroup")
 
-MetadataDatasetT = TypeVar("MetadataDatasetT", bound="MetadataDataset1D")
+MetadataLUTT = TypeVar("MetadataLUTT", bound="MetadataLUT1D")

--- a/src/nisarqa/utils/typing.py
+++ b/src/nisarqa/utils/typing.py
@@ -21,4 +21,4 @@ RunConfigDict = Mapping[
 
 RootParamGroupT = TypeVar("RootParamGroupT", bound="RootParamGroup")
 
-MetadataDatasetT = TypeVar("MetadataDataset", bound="MetadataDataset1D")
+MetadataDatasetT = TypeVar("MetadataDatasetT", bound="MetadataDataset1D")


### PR DESCRIPTION
Previously, for RSLC, GSLC, and GCOV products, all metadata datasets under the `../metadata/calibrationInformation/` Group were incorrectly being referred to as "metadata cubes".

This is noted in the original QA repo's Issues #188 and #183, and arose again during NISAR I&T's R4.0.4 testing.

This PR addresses the problem in a few ways:
* Updates the terminology from "cube" to "dataset" in most places.
* Modularizes the `verify_metadata_cubes()` function into two distinct functions:
    1) `verify_metadata_cubes()` for all L1/L2 products, which only checks the metadata cubes under the `radarGrid` or `geolocationGrid` Group
    2) `verify_calibration_metadata()` which is only for non-InSAR products (RSLC, GSLC, GCOV), which specifically handles metadata under the `../metadata/calibrationInformation/` Group

While revising this part of the code, I updated the verification checks so that GSLC now has its `geometry` metadata checked, and so that GSLC+GCOV have a warning logged re: their `crosstalk` metadata not being checked.