### PR TITLE
Bugfix: Remove InSAR dtype check in product reader

### DIFF
--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -3451,47 +3451,6 @@ class InsarProduct(NisarProduct):
         # So, treat this as a wrapper function.
         return h5_file[raster_path]
 
-    def _check_dtype(self, path: str, expected_dtype: np.dtype) -> None:
-        """
-        Check that the dataset found at `path` has the correct dtype.
-
-        Parameters
-        ----------
-        path : str
-            Path to a dataset inside the input product.
-        expected_dtype : np.dtype
-            The expected dtype for the dataset, e.g. np.complex64.
-        """
-
-        # Use lru_cache to minimize the amount of (slow) file i/o
-        @lru_cache
-        def _check_dtype_inner(path: str, expected_dtype: np.dtype) -> None:
-            with h5py.File(self.filepath) as f:
-                try:
-                    dataset_handle = f[path]
-                except KeyError:
-                    raise nisarqa.DatasetNotFoundError
-
-                product_dtype = dataset_handle.dtype
-
-            # dataset.dtype returns e.g. "<f4" for NISAR products.
-            # Use .base to convert to equivalent native numpy dtype.
-            log = nisarqa.get_logger()
-            # If the check passes, log as 'INFO', otherwise log as 'WARNING'
-            pass_fail, logger = (
-                ("PASS", log.info)
-                if (product_dtype.base == expected_dtype)
-                else ("FAIL", log.error)
-            )
-
-            logger(
-                f"({pass_fail}) PASS/FAIL Check: Input file's dataset has"
-                f" type {product_dtype} which conforms to expected dtype"
-                f" {expected_dtype}. Dataset: {path}"
-            )
-
-        _check_dtype_inner(path, expected_dtype)
-
     @abstractmethod
     def _get_path_containing_freq_pol(self, freq: str, pol: str) -> str:
         """
@@ -3657,7 +3616,6 @@ class WrappedGroup(InsarProduct):
         """
         parent_path = self._wrapped_group_path(freq=freq, pol=pol)
         path = f"{parent_path}/wrappedInterferogram"
-        self._check_dtype(path=path, expected_dtype=np.complex64)
 
         with h5py.File(self.filepath) as f:
             yield self._get_raster_from_path(
@@ -3683,7 +3641,6 @@ class WrappedGroup(InsarProduct):
         """
         parent_path = self._wrapped_group_path(freq=freq, pol=pol)
         path = f"{parent_path}/coherenceMagnitude"
-        self._check_dtype(path=path, expected_dtype=np.float32)
 
         with h5py.File(self.filepath) as f:
             yield self._get_raster_from_path(
@@ -3727,7 +3684,6 @@ class UnwrappedGroup(InsarProduct):
         """
         parent_path = self._unwrapped_group_path(freq=freq, pol=pol)
         path = f"{parent_path}/unwrappedPhase"
-        self._check_dtype(path=path, expected_dtype=np.float32)
 
         with h5py.File(self.filepath) as f:
             yield self._get_raster_from_path(
@@ -3753,7 +3709,6 @@ class UnwrappedGroup(InsarProduct):
         """
         parent_path = self._unwrapped_group_path(freq=freq, pol=pol)
         path = f"{parent_path}/connectedComponents"
-        self._check_dtype(path=path, expected_dtype=np.uint32)
 
         with h5py.File(self.filepath) as f:
             yield self._get_raster_from_path(
@@ -3779,7 +3734,6 @@ class UnwrappedGroup(InsarProduct):
         """
         parent_path = self._unwrapped_group_path(freq=freq, pol=pol)
         path = f"{parent_path}/coherenceMagnitude"
-        self._check_dtype(path=path, expected_dtype=np.float32)
 
         with h5py.File(self.filepath) as f:
             yield self._get_raster_from_path(
@@ -3805,7 +3759,6 @@ class UnwrappedGroup(InsarProduct):
         """
         parent_path = self._unwrapped_group_path(freq=freq, pol=pol)
         path = f"{parent_path}/ionospherePhaseScreen"
-        self._check_dtype(path=path, expected_dtype=np.float32)
 
         with h5py.File(self.filepath) as f:
             yield self._get_raster_from_path(
@@ -3831,7 +3784,6 @@ class UnwrappedGroup(InsarProduct):
         """
         parent_path = self._unwrapped_group_path(freq=freq, pol=pol)
         path = f"{parent_path}/ionospherePhaseScreenUncertainty"
-        self._check_dtype(path=path, expected_dtype=np.float32)
 
         with h5py.File(self.filepath) as f:
             yield self._get_raster_from_path(
@@ -3885,7 +3837,6 @@ class IgramOffsetsGroup(InsarProduct):
         """
         parent_path = self._igram_offsets_group_path(freq=freq, pol=pol)
         path = f"{parent_path}/alongTrackOffset"
-        self._check_dtype(path=path, expected_dtype=np.float32)
 
         with h5py.File(self.filepath) as f:
             yield self._get_raster_from_path(
@@ -3911,7 +3862,6 @@ class IgramOffsetsGroup(InsarProduct):
         """
         parent_path = self._igram_offsets_group_path(freq=freq, pol=pol)
         path = f"{parent_path}/slantRangeOffset"
-        self._check_dtype(path=path, expected_dtype=np.float32)
 
         with h5py.File(self.filepath) as f:
             yield self._get_raster_from_path(
@@ -3937,7 +3887,6 @@ class IgramOffsetsGroup(InsarProduct):
         """
         parent_path = self._igram_offsets_group_path(freq=freq, pol=pol)
         path = f"{parent_path}/correlationSurfacePeak"
-        self._check_dtype(path=path, expected_dtype=np.float32)
 
         with h5py.File(self.filepath) as f:
             yield self._get_raster_from_path(
@@ -4264,7 +4213,6 @@ class OffsetProduct(InsarProduct):
         """
         parent_path = self._numbered_layer_group_path(freq, pol, layer_num)
         path = f"{parent_path}/alongTrackOffset"
-        self._check_dtype(path=path, expected_dtype=np.float32)
 
         with h5py.File(self.filepath) as f:
             yield self._get_raster_from_path(
@@ -4293,7 +4241,6 @@ class OffsetProduct(InsarProduct):
         """
         parent_path = self._numbered_layer_group_path(freq, pol, layer_num)
         path = f"{parent_path}/slantRangeOffset"
-        self._check_dtype(path=path, expected_dtype=np.float32)
 
         with h5py.File(self.filepath) as f:
             yield self._get_raster_from_path(
@@ -4322,7 +4269,6 @@ class OffsetProduct(InsarProduct):
         """
         parent_path = self._numbered_layer_group_path(freq, pol, layer_num)
         path = f"{parent_path}/alongTrackOffsetVariance"
-        self._check_dtype(path=path, expected_dtype=np.float32)
 
         with h5py.File(self.filepath) as f:
             yield self._get_raster_from_path(
@@ -4351,7 +4297,6 @@ class OffsetProduct(InsarProduct):
         """
         parent_path = self._numbered_layer_group_path(freq, pol, layer_num)
         path = f"{parent_path}/slantRangeOffsetVariance"
-        self._check_dtype(path=path, expected_dtype=np.float32)
 
         with h5py.File(self.filepath) as f:
             yield self._get_raster_from_path(
@@ -4380,7 +4325,6 @@ class OffsetProduct(InsarProduct):
         """
         parent_path = self._numbered_layer_group_path(freq, pol, layer_num)
         path = f"{parent_path}/crossOffsetVariance"
-        self._check_dtype(path=path, expected_dtype=np.float32)
 
         with h5py.File(self.filepath) as f:
             yield self._get_raster_from_path(
@@ -4409,7 +4353,6 @@ class OffsetProduct(InsarProduct):
         """
         parent_path = self._numbered_layer_group_path(freq, pol, layer_num)
         path = f"{parent_path}/correlationSurfacePeak"
-        self._check_dtype(path=path, expected_dtype=np.float32)
 
         with h5py.File(self.filepath) as f:
             yield self._get_raster_from_path(


### PR DESCRIPTION
## Background
For historical reasons, the InSAR product reader had a dtype check built into it. This check required that the QA developer know apriori the dtype of each dataset, and maintain the QA code if/when the product spec changed. This check in the product reader was intended to be a stop-gap, to be used until the actual QA XML checker was implemented and could algorithmically check the dtypes in the HDF5 file against the actual XML product specs for all datasets. That way, if/when the product spec XMLs are updated, then QA would get that update "for free".

The QA XML checker has since been implemented, and the XML vs. HDF5 dtypes are now being checked via [this function](https://github.com/isce-framework/nisarqa/blob/90dbb9e76442eda6dc34d8ed76f2225187ee22c4/src/nisarqa/utils/file_verification/checks.py#L534).

## Issue
This means that there are two independent dtype checks for the imagery datasets, and the product reader dtype for the `connectedComponents` layer has indeed fallen out of sync. In the GUNW R4.0.4 sample product, this led to a false error (aka a bug) being written in the log file.

## Solutions
There are two possible way to address:
1) Update the connected components getter to expect `uint16`, which matches the current XML product spec.
2) Remove the dtype check entirely from the reader, and let the XML Checker handle it

I lean towards option 2 because:
* Maintainability: keeps the code modular, brings the code one step towards "single responsibility", and reduces QA to having one source of truth for the dtype
* Sneakiness: The product reader does not mention dtype requirements of the datasets in the docstring; it seems strange to have it emit an error

## Discussion
I think there might be similar checks for the RSLC, GSLC, and GCOV product readers; those are potentially a bit messier (RSLC and GSLC shifted between complex32 and complex64). Would it be ok to handle them in a separate PR, or should they be updated here?