### PR TITLE
Bugfix: Update `isJointObservation` check for InSAR products

### DIFF
--- a/src/nisarqa/utils/sanity_checks.py
+++ b/src/nisarqa/utils/sanity_checks.py
@@ -213,14 +213,23 @@ def identification_sanity_checks(
         )
 
     # Verify Boolean Datasets
-    for ds_name in (
+    bool_datasets = [
         "isDithered",
         "isGeocoded",
         "isMixedMode",
         "isUrgentObservation",
-        "isJointObservation",
         "isFullFrame",
-    ):
+    ]
+
+    if product_type.lower() in nisarqa.LIST_OF_INSAR_PRODUCTS:
+        bool_datasets += [
+            "referenceIsJointObservation",
+            "secondaryIsJointObservation",
+        ]
+    else:
+        bool_datasets += ["isJointObservation"]
+
+    for ds_name in bool_datasets:
         ds_checked.add(ds_name)
         if _dataset_exists(ds_name):
             data = _get_string_dataset(ds_name=ds_name)


### PR DESCRIPTION
Currently, QA assumes that all L1 and L2 products contain a boolean dataset `../identification/isJointObservation`.

That is true for the single-input products (RSLC, GSLC, GCOV). But for InSAR, this needs to be split into [`../identification/referenceIsJointObservation`](https://github-fn.jpl.nasa.gov/NISAR-ADT/NISAR_PIX/blob/f9a912736432837ba3d05494c0b45cdefe69288a/XML/L2/nisar_L2_GUNW.xml#L35) and [`../identification/secondaryIsJointObservation`](https://github-fn.jpl.nasa.gov/NISAR-ADT/NISAR_PIX/blob/f9a912736432837ba3d05494c0b45cdefe69288a/XML/L2/nisar_L2_GUNW.xml#L41).

This discrepancy is causing a false error to be written in the InSAR QA log file. This PR address that bug.