### PR TITLE
Move `typing.py` module to its own public submodule

### DIFF
--- a/src/nisarqa/__init__.py
+++ b/src/nisarqa/__init__.py
@@ -147,6 +147,6 @@ from .utils.tiling import *
 from .utils.summary_csv import *
 from .utils.metrics_writer import *
 from .utils.sanity_checks import *
-from .utils.typing import *
+from .utils import typing
 
 # isort: on

--- a/src/nisarqa/parameters/nisar_params.py
+++ b/src/nisarqa/parameters/nisar_params.py
@@ -1532,16 +1532,16 @@ class RootParamGroup(ABC):
 
     @classmethod
     def from_runconfig_dict(
-        cls: type[nisarqa.RootParamGroupT],
-        user_rncfg: nisarqa.RunConfigDict,
+        cls: type[nisarqa.typing.RootParamGroupT],
+        user_rncfg: nisarqa.typing.RunConfigDict,
         product_type: str,
-    ) -> nisarqa.RootParamGroupT:
+    ) -> nisarqa.typing.RootParamGroupT:
         """
         Build a *RootParamGroup for `product_type` from a QA runconfig dict.
 
         Parameters
         ----------
-        user_rncfg : nisarqa.RunConfigDict
+        user_rncfg : nisarqa.typing.RunConfigDict
             A dictionary whose structure matches `product_type`'s QA runconfig
             YAML file and that contains the parameters needed to run its QA SAS.
         product_type : str
@@ -1550,7 +1550,7 @@ class RootParamGroup(ABC):
 
         Returns
         -------
-        root_params : nisarqa.RootParamGroup
+        root_params : nisarqa.typing.RootParamGroupT
             *RootParamGroup object for the specified product type. This will be
             populated with runconfig values where provided,
             and default values for missing runconfig parameters.
@@ -1714,10 +1714,10 @@ class RootParamGroup(ABC):
 
     @classmethod
     def from_runconfig_file(
-        cls: type[nisarqa.RootParamGroupT],
+        cls: type[nisarqa.typing.RootParamGroupT],
         runconfig_yaml: str | os.PathLike,
         product_type: str,
-    ) -> nisarqa.RootParamGroupT:
+    ) -> nisarqa.typing.RootParamGroupT:
         """
         Get a *RootParamGroup for `product_type` from a QA Runconfig YAML file.
 
@@ -1737,7 +1737,7 @@ class RootParamGroup(ABC):
 
         Returns
         -------
-        root_params : nisarqa.RootParamGroup
+        root_params : nisarqa.typing.RootParamGroupT
             An instance of *RootParamGroup corresponding to `product_type`.
             For example, if `product_type` is 'gcov', the return type
             will be `nisarqa.GCOVRootParamGroup`. This will be

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -1198,7 +1198,7 @@ class NisarProduct(ABC):
         self,
         f: h5py.File,
         ds_arr: h5py.Dataset,
-    ) -> nisarqa.MetadataLUTT:
+    ) -> nisarqa.typing.MetadataLUTT:
         """
         Construct a MetadataLUT for the given 1D, 2D, or 3D LUT.
 
@@ -1211,7 +1211,7 @@ class NisarProduct(ABC):
 
         Returns
         -------
-        ds : nisarqa.MetadataLUTT
+        ds : nisarqa.typing.MetadataLUTT
             A constructed MetadataLUT of `ds_arr`. The number of dimensions
             of `ds_arr` determines whether a MetadataLUT1D, *2D, or *3D
             is returned.

--- a/src/nisarqa/utils/metadata_checks.py
+++ b/src/nisarqa/utils/metadata_checks.py
@@ -441,13 +441,13 @@ def is_gdal_friendly(input_filepath: str, ds_path: str) -> bool:
         return False
 
 
-def _lut_has_finite_pixels(ds: nisarqa.MetadataLUTT) -> bool:
+def _lut_has_finite_pixels(ds: nisarqa.typing.MetadataLUTT) -> bool:
     """
     Return False if LUT contains all non-finite values; True otherwise.
 
     Parameters
     ----------
-    ds : nisarqa.MetadataLUTT
+    ds : nisarqa.typing.MetadataLUTT
         Metadata LUT to be checked.
 
     Returns
@@ -481,13 +481,13 @@ def _lut_has_finite_pixels(ds: nisarqa.MetadataLUTT) -> bool:
     return True
 
 
-def _lut_is_not_all_zeros(ds: nisarqa.MetadataLUTT) -> bool:
+def _lut_is_not_all_zeros(ds: nisarqa.typing.MetadataLUTT) -> bool:
     """
     Return False if metadata LUT contains all near-zeros; True otherwise.
 
     Parameters
     ----------
-    ds : nisarqa.MetadataLUTT
+    ds : nisarqa.typing.MetadataLUTT
         Metadata LUT to be checked.
 
     Returns

--- a/src/nisarqa/utils/sanity_checks.py
+++ b/src/nisarqa/utils/sanity_checks.py
@@ -87,8 +87,8 @@ def identification_sanity_checks(
         return True
 
     def _verify_data_is_in_list(
-        value: nisarqa.T | None,
-        valid_options: Container[nisarqa.T],
+        value: nisarqa.typing.T | None,
+        valid_options: Container[nisarqa.typing.T],
         ds_name: str,
     ) -> bool:
         if (value is None) or (value not in valid_options):

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -506,8 +506,8 @@ def log_runtime(msg: str) -> Generator[None, None, None]:
 
 
 def log_function_runtime(
-    func: Callable[..., nisarqa.T],
-) -> Callable[..., nisarqa.T]:
+    func: Callable[..., nisarqa.typing.T],
+) -> Callable[..., nisarqa.typing.T]:
     """
     Function decorator to log the runtime of a function.
 
@@ -546,7 +546,7 @@ def ignore_runtime_warnings() -> Iterator[None]:
 
 def load_user_runconfig(
     runconfig_yaml: str | os.PathLike,
-) -> nisarqa.RunConfigDict:
+) -> nisarqa.typing.RunConfigDict:
     """
     Load a QA runconfig YAML file into a dict format.
 
@@ -557,7 +557,7 @@ def load_user_runconfig(
 
     Returns
     -------
-    user_rncfg : nisarqa.RunConfigDict
+    user_rncfg : nisarqa.typing.RunConfigDict
         `runconfig_yaml` loaded into a dict format
     """
     # parse runconfig into a dict structure


### PR DESCRIPTION
This PR puts QA's `typing.py` module to its own public submodule, as suggested and reasoned in: https://github.com/isce-framework/nisarqa/pull/21#discussion_r2047657578 .