### PR TITLE
Speedup: Add `memmap` cache for RSLC, GSLC, GCOV

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,3 @@ repos:
     rev: "24.10.0"
     hooks:
       - id: black
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 6.0.1
-    hooks:
-      - id: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,8 @@ repos:
     rev: "24.10.0"
     hooks:
       - id: black
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,6 @@ nisarqa = "nisarqa.__main__:main"
 [tool.black]
 preview = true
 line-length = 80
+
+[tool.isort]
+profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,3 @@ nisarqa = "nisarqa.__main__:main"
 [tool.black]
 preview = true
 line-length = 80
-
-[tool.isort]
-profile = "black"

--- a/src/nisarqa/__init__.py
+++ b/src/nisarqa/__init__.py
@@ -116,6 +116,8 @@ from .parameters.rslc_caltools_params import *
 from .parameters.gslc_params import *
 from .parameters.gcov_params import *
 from .parameters.insar_params import *
+from .utils import typing
+from .utils.utils import *
 from .products.product_reader import *
 from .utils.file_verification.policy import *
 from .utils.file_verification.data_annotation import *
@@ -128,7 +130,6 @@ from .utils.file_verification.xml_check import *
 from .utils.file_verification.xml_parser import *
 
 from .utils.metadata_checks import *
-from .utils.utils import *
 
 # keep individual products in their own namespace
 from .products import (
@@ -150,6 +151,5 @@ from .utils.summary_csv import *
 from .utils.stats_h5_writer.metrics_writer import *
 from .utils.stats_h5_writer.setup_writer import *
 from .utils.sanity_checks import *
-from .utils import typing
 
 # isort: on

--- a/src/nisarqa/__main__.py
+++ b/src/nisarqa/__main__.py
@@ -186,18 +186,24 @@ def run():
 
     # Run QA SAS
     verbose = args.verbose
-    if subcommand == "rslc_qa":
-        nisarqa.rslc.verify_rslc(root_params=root_params, verbose=verbose)
-    elif subcommand == "gslc_qa":
-        nisarqa.gslc.verify_gslc(root_params=root_params, verbose=verbose)
-    elif subcommand == "gcov_qa":
-        nisarqa.gcov.verify_gcov(root_params=root_params, verbose=verbose)
-    elif subcommand in ("rifg_qa", "runw_qa", "gunw_qa"):
-        nisarqa.igram.verify_igram(root_params=root_params, verbose=verbose)
-    elif subcommand in ("roff_qa", "goff_qa"):
-        nisarqa.offsets.verify_offset(root_params=root_params, verbose=verbose)
-    else:
-        raise ValueError(f"Unknown subcommand: {subcommand}")
+    with nisarqa.scratch_directory_manager(
+        dir_=root_params.prodpath.scratch_dir,
+        delete=root_params.software_config.delete_scratch_dir,
+    ):
+        if subcommand == "rslc_qa":
+            nisarqa.rslc.verify_rslc(root_params=root_params, verbose=verbose)
+        elif subcommand == "gslc_qa":
+            nisarqa.gslc.verify_gslc(root_params=root_params, verbose=verbose)
+        elif subcommand == "gcov_qa":
+            nisarqa.gcov.verify_gcov(root_params=root_params, verbose=verbose)
+        elif subcommand in ("rifg_qa", "runw_qa", "gunw_qa"):
+            nisarqa.igram.verify_igram(root_params=root_params, verbose=verbose)
+        elif subcommand in ("roff_qa", "goff_qa"):
+            nisarqa.offsets.verify_offset(
+                root_params=root_params, verbose=verbose
+            )
+        else:
+            raise ValueError(f"Unknown subcommand: {subcommand}")
 
 
 def main():

--- a/src/nisarqa/__main__.py
+++ b/src/nisarqa/__main__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import os
-
 import matplotlib
 
 # Switch backend to one that doesn't require DISPLAY to be set since we're

--- a/src/nisarqa/__main__.py
+++ b/src/nisarqa/__main__.py
@@ -186,10 +186,15 @@ def run():
 
     # Run QA SAS
     verbose = args.verbose
-    with nisarqa.scratch_directory_manager(
-        dir_=root_params.prodpath.scratch_dir,
-        delete=root_params.software_config.delete_scratch_dir,
-    ):
+
+    with nisarqa.create_unique_subdirectory(
+        parent_dir=root_params.prodpath.scratch_dir_parent,
+        prefix="qa_",
+        delete=root_params.software_config.delete_scratch_files,
+    ) as scratch_dir:
+
+        nisarqa.set_global_scratch_dir(scratch_dir)
+
         if subcommand == "rslc_qa":
             nisarqa.rslc.verify_rslc(root_params=root_params, verbose=verbose)
         elif subcommand == "gslc_qa":

--- a/src/nisarqa/__main__.py
+++ b/src/nisarqa/__main__.py
@@ -189,7 +189,7 @@ def run():
 
     with nisarqa.create_unique_subdirectory(
         parent_dir=root_params.prodpath.scratch_dir_parent,
-        prefix="qa_",
+        prefix=f"qa-{product_type}",
         delete=root_params.software_config.delete_scratch_files,
     ) as scratch_dir:
 

--- a/src/nisarqa/parameters/constants/globals.py
+++ b/src/nisarqa/parameters/constants/globals.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-from functools import cache
 from itertools import product
 from pathlib import Path
 

--- a/src/nisarqa/parameters/constants/globals.py
+++ b/src/nisarqa/parameters/constants/globals.py
@@ -144,8 +144,6 @@ PRODUCT_SPECS_PATH = Path(__file__).parent.parent / "product_specs"
 
 complex32 = np.dtype([("r", np.float16), ("i", np.float16)])
 
-_image_cache_dict: dict = {}
-
 
 # The are global constants and not functions nor classes,
 # so manually create the __all__ attribute.
@@ -170,5 +168,4 @@ __all__ = [
     "GCOV_OFF_DIAG_POLS",
     "SEABORN_COLORBLIND",
     "complex32",
-    "_image_cache_dict",
 ]

--- a/src/nisarqa/parameters/constants/globals.py
+++ b/src/nisarqa/parameters/constants/globals.py
@@ -144,6 +144,9 @@ PRODUCT_SPECS_PATH = Path(__file__).parent.parent / "product_specs"
 
 complex32 = np.dtype([("r", np.float16), ("i", np.float16)])
 
+_image_cache_dict: dict = {}
+
+
 # The are global constants and not functions nor classes,
 # so manually create the __all__ attribute.
 __all__ = [
@@ -167,4 +170,5 @@ __all__ = [
     "GCOV_OFF_DIAG_POLS",
     "SEABORN_COLORBLIND",
     "complex32",
+    "_image_cache_dict",
 ]

--- a/src/nisarqa/parameters/gcov_params.py
+++ b/src/nisarqa/parameters/gcov_params.py
@@ -7,8 +7,9 @@ from typing import Optional
 import nisarqa
 from nisarqa.parameters.nisar_params import (
     InputFileGroupParamGroup,
-    ProductPathGroupParamGroup,
-    RootParamGroup,
+    ScratchProductPathGroupParamGroup,
+    SoftwareConfigGroupParamGroup,
+    NonInsarRootParamGroup,
     ValidationGroupParamGroup,
     WorkflowsParamGroup,
 )
@@ -84,7 +85,7 @@ class GCOVHistogramParamGroup(HistogramParamGroup):
 
 
 @dataclass
-class GCOVRootParamGroup(RootParamGroup):
+class GCOVRootParamGroup(NonInsarRootParamGroup):
     """
     Dataclass of all *ParamGroup objects to process QA for NISAR GCOV products.
 
@@ -101,8 +102,10 @@ class GCOVRootParamGroup(RootParamGroup):
         QA Workflows parameters
     input_f : InputFileGroupParamGroup or None, optional
         Input File Group parameters for QA
-    prodpath : ProductPathGroupParamGroup or None, optional
+    prodpath : ScratchProductPathGroupParamGroup or None, optional
         Product Path Group parameters for QA
+    software_config : SoftwareConfigParamGroup or None, optional
+        General QA Software Configuration Group parameters
     validation : ValidationGroupParamGroup or None, optional
         Validation Group parameters for QA
     backscatter_img : BackscatterImageParamGroup or None, optional
@@ -111,9 +114,8 @@ class GCOVRootParamGroup(RootParamGroup):
         Histogram Group parameters for GCOV QA
     """
 
-    # Shared parameters
-    input_f: Optional[InputFileGroupParamGroup] = None
-    prodpath: Optional[ProductPathGroupParamGroup] = None
+    # Overwrite parent's attributes b/c new type
+    prodpath: Optional[ScratchProductPathGroupParamGroup] = None
 
     # QA parameters
     backscatter_img: Optional[BackscatterImageParamGroup] = None
@@ -121,7 +123,9 @@ class GCOVRootParamGroup(RootParamGroup):
 
     @staticmethod
     def get_mapping_of_workflows2param_grps(workflows):
-        Grp = RootParamGroup.ReqParamGrp  # class object for our named tuple
+        Grp = (
+            NonInsarRootParamGroup.ReqParamGrp
+        )  # class object for our named tuple
 
         flag_any_workflows_true = any(
             [getattr(workflows, field.name) for field in fields(workflows)]
@@ -136,7 +140,12 @@ class GCOVRootParamGroup(RootParamGroup):
             Grp(
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
-                param_grp_cls_obj=ProductPathGroupParamGroup,
+                param_grp_cls_obj=ScratchProductPathGroupParamGroup,
+            ),
+            Grp(
+                flag_param_grp_req=flag_any_workflows_true,
+                root_param_grp_attr_name="software_config",
+                param_grp_cls_obj=SoftwareConfigGroupParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -163,8 +172,9 @@ class GCOVRootParamGroup(RootParamGroup):
         # the groups will appear in the runconfig.
         return {
             "input_f": InputFileGroupParamGroup,
-            "prodpath": ProductPathGroupParamGroup,
+            "prodpath": ScratchProductPathGroupParamGroup,
             "workflows": WorkflowsParamGroup,
+            "software_config": SoftwareConfigGroupParamGroup,
             "validation": ValidationGroupParamGroup,
             "backscatter_img": BackscatterImageParamGroup,
             "histogram": GCOVHistogramParamGroup,

--- a/src/nisarqa/parameters/gcov_params.py
+++ b/src/nisarqa/parameters/gcov_params.py
@@ -7,9 +7,9 @@ from typing import Optional
 import nisarqa
 from nisarqa.parameters.nisar_params import (
     InputFileGroupParamGroup,
+    NonInsarRootParamGroup,
     ScratchProductPathGroupParamGroup,
     SoftwareConfigGroupParamGroup,
-    NonInsarRootParamGroup,
     ValidationGroupParamGroup,
     WorkflowsParamGroup,
 )

--- a/src/nisarqa/parameters/gcov_params.py
+++ b/src/nisarqa/parameters/gcov_params.py
@@ -114,9 +114,6 @@ class GCOVRootParamGroup(RootParamGroup):
         Histogram Group parameters for GCOV QA
     """
 
-    # Overwrite parent's attributes b/c new type
-    prodpath: Optional[ProductPathGroupParamGroup] = None
-
     # QA parameters
     backscatter_img: Optional[BackscatterImageParamGroup] = None
     histogram: Optional[GCOVHistogramParamGroup] = None

--- a/src/nisarqa/parameters/gcov_params.py
+++ b/src/nisarqa/parameters/gcov_params.py
@@ -7,9 +7,9 @@ from typing import Optional
 import nisarqa
 from nisarqa.parameters.nisar_params import (
     InputFileGroupParamGroup,
-    NonInsarRootParamGroup,
-    ScratchProductPathGroupParamGroup,
-    SoftwareConfigGroupParamGroup,
+    ProductPathGroupParamGroup,
+    RootParamGroup,
+    SoftwareConfigParamGroup,
     ValidationGroupParamGroup,
     WorkflowsParamGroup,
 )
@@ -85,7 +85,7 @@ class GCOVHistogramParamGroup(HistogramParamGroup):
 
 
 @dataclass
-class GCOVRootParamGroup(NonInsarRootParamGroup):
+class GCOVRootParamGroup(RootParamGroup):
     """
     Dataclass of all *ParamGroup objects to process QA for NISAR GCOV products.
 
@@ -102,7 +102,7 @@ class GCOVRootParamGroup(NonInsarRootParamGroup):
         QA Workflows parameters
     input_f : InputFileGroupParamGroup or None, optional
         Input File Group parameters for QA
-    prodpath : ScratchProductPathGroupParamGroup or None, optional
+    prodpath : ProductPathGroupParamGroup or None, optional
         Product Path Group parameters for QA
     software_config : SoftwareConfigParamGroup or None, optional
         General QA Software Configuration Group parameters
@@ -115,7 +115,7 @@ class GCOVRootParamGroup(NonInsarRootParamGroup):
     """
 
     # Overwrite parent's attributes b/c new type
-    prodpath: Optional[ScratchProductPathGroupParamGroup] = None
+    prodpath: Optional[ProductPathGroupParamGroup] = None
 
     # QA parameters
     backscatter_img: Optional[BackscatterImageParamGroup] = None
@@ -123,9 +123,7 @@ class GCOVRootParamGroup(NonInsarRootParamGroup):
 
     @staticmethod
     def get_mapping_of_workflows2param_grps(workflows):
-        Grp = (
-            NonInsarRootParamGroup.ReqParamGrp
-        )  # class object for our named tuple
+        Grp = RootParamGroup.ReqParamGrp  # class object for our named tuple
 
         flag_any_workflows_true = any(
             [getattr(workflows, field.name) for field in fields(workflows)]
@@ -140,12 +138,12 @@ class GCOVRootParamGroup(NonInsarRootParamGroup):
             Grp(
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
-                param_grp_cls_obj=ScratchProductPathGroupParamGroup,
+                param_grp_cls_obj=ProductPathGroupParamGroup,
             ),
             Grp(
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="software_config",
-                param_grp_cls_obj=SoftwareConfigGroupParamGroup,
+                param_grp_cls_obj=SoftwareConfigParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -172,9 +170,9 @@ class GCOVRootParamGroup(NonInsarRootParamGroup):
         # the groups will appear in the runconfig.
         return {
             "input_f": InputFileGroupParamGroup,
-            "prodpath": ScratchProductPathGroupParamGroup,
+            "prodpath": ProductPathGroupParamGroup,
             "workflows": WorkflowsParamGroup,
-            "software_config": SoftwareConfigGroupParamGroup,
+            "software_config": SoftwareConfigParamGroup,
             "validation": ValidationGroupParamGroup,
             "backscatter_img": BackscatterImageParamGroup,
             "histogram": GCOVHistogramParamGroup,

--- a/src/nisarqa/parameters/gslc_params.py
+++ b/src/nisarqa/parameters/gslc_params.py
@@ -7,11 +7,11 @@ from nisarqa import (
     DynamicAncillaryFileParamGroup,
     HistogramParamGroup,
     InputFileGroupParamGroup,
+    NonInsarRootParamGroup,
     PointTargetAnalyzerParamGroup,
     ScratchProductPathGroupParamGroup,
-    SoftwareConfigGroupParamGroup,
-    NonInsarRootParamGroup,
     SLCWorkflowsParamGroup,
+    SoftwareConfigGroupParamGroup,
     ValidationGroupParamGroup,
     YamlAttrs,
 )

--- a/src/nisarqa/parameters/gslc_params.py
+++ b/src/nisarqa/parameters/gslc_params.py
@@ -8,8 +8,9 @@ from nisarqa import (
     HistogramParamGroup,
     InputFileGroupParamGroup,
     PointTargetAnalyzerParamGroup,
-    ProductPathGroupParamGroup,
-    RootParamGroup,
+    ScratchProductPathGroupParamGroup,
+    SoftwareConfigGroupParamGroup,
+    NonInsarRootParamGroup,
     SLCWorkflowsParamGroup,
     ValidationGroupParamGroup,
     YamlAttrs,
@@ -85,7 +86,7 @@ class GSLCDynamicAncillaryFileParamGroup(DynamicAncillaryFileParamGroup):
 
 
 @dataclass
-class GSLCRootParamGroup(RootParamGroup):
+class GSLCRootParamGroup(NonInsarRootParamGroup):
     """
     Dataclass of all *ParamGroup objects to process QA for NISAR GSLC products.
 
@@ -102,8 +103,10 @@ class GSLCRootParamGroup(RootParamGroup):
         GSLC QA Workflows parameters
     input_f : InputFileGroupParamGroup or None, optional
         Input File Group parameters for QA
-    prodpath : ProductPathGroupParamGroup or None, optional
+    prodpath : ScratchProductPathGroupParamGroup or None, optional
         Product Path Group parameters for QA
+    software_config : SoftwareConfigParamGroup or None, optional
+        General QA Software Configuration Group parameters
     validation : ValidationGroupParamGroup or None, optional
         Validation Group parameters for QA
     backscatter_img : BackscatterImageParamGroup or None, optional
@@ -116,10 +119,9 @@ class GSLCRootParamGroup(RootParamGroup):
         Point Target Analyzer group parameters for GSLC QA-Caltools
     """
 
-    # Shared parameters
-    workflows: (
-        SLCWorkflowsParamGroup  # overwrite parent's `workflows` b/c new type
-    )
+    # Overwrite parent's attributes b/c new type
+    workflows: SLCWorkflowsParamGroup
+    prodpath: ScratchProductPathGroupParamGroup = None
 
     # QA parameters
     backscatter_img: Optional[BackscatterImageParamGroup] = None
@@ -167,7 +169,9 @@ class GSLCRootParamGroup(RootParamGroup):
 
     @staticmethod
     def get_mapping_of_workflows2param_grps(workflows):
-        Grp = RootParamGroup.ReqParamGrp  # class object for our named tuple
+        Grp = (
+            NonInsarRootParamGroup.ReqParamGrp
+        )  # class object for our named tuple
 
         flag_any_workflows_true = any(
             [getattr(workflows, field.name) for field in fields(workflows)]
@@ -182,7 +186,12 @@ class GSLCRootParamGroup(RootParamGroup):
             Grp(
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
-                param_grp_cls_obj=ProductPathGroupParamGroup,
+                param_grp_cls_obj=ScratchProductPathGroupParamGroup,
+            ),
+            Grp(
+                flag_param_grp_req=flag_any_workflows_true,
+                root_param_grp_attr_name="software_config",
+                param_grp_cls_obj=SoftwareConfigGroupParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -220,8 +229,9 @@ class GSLCRootParamGroup(RootParamGroup):
         return {
             "input_f": InputFileGroupParamGroup,
             "anc_files": GSLCDynamicAncillaryFileParamGroup,
-            "prodpath": ProductPathGroupParamGroup,
+            "prodpath": ScratchProductPathGroupParamGroup,
             "workflows": SLCWorkflowsParamGroup,
+            "software_config": SoftwareConfigGroupParamGroup,
             "validation": ValidationGroupParamGroup,
             "backscatter_img": BackscatterImageParamGroup,
             "histogram": HistogramParamGroup,

--- a/src/nisarqa/parameters/gslc_params.py
+++ b/src/nisarqa/parameters/gslc_params.py
@@ -7,11 +7,11 @@ from nisarqa import (
     DynamicAncillaryFileParamGroup,
     HistogramParamGroup,
     InputFileGroupParamGroup,
-    NonInsarRootParamGroup,
     PointTargetAnalyzerParamGroup,
-    ScratchProductPathGroupParamGroup,
+    ProductPathGroupParamGroup,
+    RootParamGroup,
     SLCWorkflowsParamGroup,
-    SoftwareConfigGroupParamGroup,
+    SoftwareConfigParamGroup,
     ValidationGroupParamGroup,
     YamlAttrs,
 )
@@ -86,7 +86,7 @@ class GSLCDynamicAncillaryFileParamGroup(DynamicAncillaryFileParamGroup):
 
 
 @dataclass
-class GSLCRootParamGroup(NonInsarRootParamGroup):
+class GSLCRootParamGroup(RootParamGroup):
     """
     Dataclass of all *ParamGroup objects to process QA for NISAR GSLC products.
 
@@ -103,7 +103,7 @@ class GSLCRootParamGroup(NonInsarRootParamGroup):
         GSLC QA Workflows parameters
     input_f : InputFileGroupParamGroup or None, optional
         Input File Group parameters for QA
-    prodpath : ScratchProductPathGroupParamGroup or None, optional
+    prodpath : ProductPathGroupParamGroup or None, optional
         Product Path Group parameters for QA
     software_config : SoftwareConfigParamGroup or None, optional
         General QA Software Configuration Group parameters
@@ -121,7 +121,7 @@ class GSLCRootParamGroup(NonInsarRootParamGroup):
 
     # Overwrite parent's attributes b/c new type
     workflows: SLCWorkflowsParamGroup
-    prodpath: ScratchProductPathGroupParamGroup = None
+    prodpath: ProductPathGroupParamGroup = None
 
     # QA parameters
     backscatter_img: Optional[BackscatterImageParamGroup] = None
@@ -169,9 +169,7 @@ class GSLCRootParamGroup(NonInsarRootParamGroup):
 
     @staticmethod
     def get_mapping_of_workflows2param_grps(workflows):
-        Grp = (
-            NonInsarRootParamGroup.ReqParamGrp
-        )  # class object for our named tuple
+        Grp = RootParamGroup.ReqParamGrp  # class object for our named tuple
 
         flag_any_workflows_true = any(
             [getattr(workflows, field.name) for field in fields(workflows)]
@@ -186,12 +184,12 @@ class GSLCRootParamGroup(NonInsarRootParamGroup):
             Grp(
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
-                param_grp_cls_obj=ScratchProductPathGroupParamGroup,
+                param_grp_cls_obj=ProductPathGroupParamGroup,
             ),
             Grp(
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="software_config",
-                param_grp_cls_obj=SoftwareConfigGroupParamGroup,
+                param_grp_cls_obj=SoftwareConfigParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -229,9 +227,9 @@ class GSLCRootParamGroup(NonInsarRootParamGroup):
         return {
             "input_f": InputFileGroupParamGroup,
             "anc_files": GSLCDynamicAncillaryFileParamGroup,
-            "prodpath": ScratchProductPathGroupParamGroup,
+            "prodpath": ProductPathGroupParamGroup,
             "workflows": SLCWorkflowsParamGroup,
-            "software_config": SoftwareConfigGroupParamGroup,
+            "software_config": SoftwareConfigParamGroup,
             "validation": ValidationGroupParamGroup,
             "backscatter_img": BackscatterImageParamGroup,
             "histogram": HistogramParamGroup,

--- a/src/nisarqa/parameters/gslc_params.py
+++ b/src/nisarqa/parameters/gslc_params.py
@@ -121,7 +121,6 @@ class GSLCRootParamGroup(RootParamGroup):
 
     # Overwrite parent's attributes b/c new type
     workflows: SLCWorkflowsParamGroup
-    prodpath: ProductPathGroupParamGroup = None
 
     # QA parameters
     backscatter_img: Optional[BackscatterImageParamGroup] = None

--- a/src/nisarqa/parameters/insar_params.py
+++ b/src/nisarqa/parameters/insar_params.py
@@ -13,6 +13,7 @@ from nisarqa import (
     InputFileGroupParamGroup,
     ProductPathGroupParamGroup,
     RootParamGroup,
+    SoftwareConfigParamGroup,
     Threshold99ParamGroup,
     ThresholdParamGroup,
     ValidationGroupParamGroup,
@@ -287,6 +288,41 @@ class GOFFWorkflowsParamGroup(WorkflowsParamGroup):
     @staticmethod
     def get_path_to_group_in_runconfig():
         return ["runconfig", "groups", "qa", "goff", "workflows"]
+
+
+@dataclass(frozen=True)
+class RIFGSoftwareConfigParamGroup(SoftwareConfigParamGroup):
+    @staticmethod
+    def get_path_to_group_in_runconfig():
+        return ["runconfig", "groups", "qa", "rifg", "software_config"]
+
+
+@dataclass(frozen=True)
+class RUNWSoftwareConfigParamGroup(SoftwareConfigParamGroup):
+    @staticmethod
+    def get_path_to_group_in_runconfig():
+        return ["runconfig", "groups", "qa", "runw", "software_config"]
+
+
+@dataclass(frozen=True)
+class GUNWSoftwareConfigParamGroup(SoftwareConfigParamGroup):
+    @staticmethod
+    def get_path_to_group_in_runconfig():
+        return ["runconfig", "groups", "qa", "gunw", "software_config"]
+
+
+@dataclass(frozen=True)
+class ROFFSoftwareConfigParamGroup(SoftwareConfigParamGroup):
+    @staticmethod
+    def get_path_to_group_in_runconfig():
+        return ["runconfig", "groups", "qa", "roff", "software_config"]
+
+
+@dataclass(frozen=True)
+class GOFFSoftwareConfigParamGroup(SoftwareConfigParamGroup):
+    @staticmethod
+    def get_path_to_group_in_runconfig():
+        return ["runconfig", "groups", "qa", "goff", "software_config"]
 
 
 @dataclass(frozen=True)
@@ -1684,6 +1720,8 @@ class RIFGRootParamGroup(RootParamGroup):
         Input File Group parameters.
     prodpath : RIFGProductPathGroupParamGroup or None, optional
         Product Path Group parameters.
+    software_config : RIFGSoftwareConfigParamGroup or None, optional
+        General QA Software Configuration Group parameters
     validation : RIFGValidationParamGroup or None, optional
         Validation Group parameters for QA
     wrapped_igram : RIFGWrappedIgramParamGroup or None, optional
@@ -1703,6 +1741,7 @@ class RIFGRootParamGroup(RootParamGroup):
     # Shared parameters
     input_f: Optional[RIFGInputFileGroupParamGroup] = None
     prodpath: Optional[RIFGProductPathGroupParamGroup] = None
+    software_config: Optional[RIFGSoftwareConfigParamGroup] = None
     validation: Optional[RIFGValidationParamGroup] = None
 
     wrapped_igram: Optional[RIFGWrappedIgramParamGroup] = None
@@ -1729,6 +1768,11 @@ class RIFGRootParamGroup(RootParamGroup):
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
                 param_grp_cls_obj=RIFGProductPathGroupParamGroup,
+            ),
+            Grp(
+                flag_param_grp_req=flag_any_workflows_true,
+                root_param_grp_attr_name="software_config",
+                param_grp_cls_obj=RIFGSoftwareConfigParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -1772,6 +1816,7 @@ class RIFGRootParamGroup(RootParamGroup):
             "input_f": RIFGInputFileGroupParamGroup,
             "prodpath": RIFGProductPathGroupParamGroup,
             "workflows": RIFGWorkflowsParamGroup,
+            "software_config": RIFGSoftwareConfigParamGroup,
             "validation": RIFGValidationParamGroup,
             "wrapped_igram": RIFGWrappedIgramParamGroup,
             "coh_mag": RIFGCohMagLayerParamGroup,
@@ -1801,6 +1846,8 @@ class RUNWRootParamGroup(RootParamGroup):
         Input File Group parameters.
     prodpath : RUNWProductPathGroupParamGroup or None, optional
         Product Path Group parameters.
+    software_config : RUNWSoftwareConfigParamGroup or None, optional
+        General QA Software Configuration Group parameters
     validation : RUNWValidationParamGroup or None, optional
         Validation Group parameters for QA
     unw_phs_img : RUNWPhaseImageParamGroup or None, optional
@@ -1825,6 +1872,7 @@ class RUNWRootParamGroup(RootParamGroup):
     workflows: RUNWWorkflowsParamGroup
     input_f: Optional[RUNWInputFileGroupParamGroup] = None
     prodpath: Optional[RUNWProductPathGroupParamGroup] = None
+    software_config: Optional[RUNWSoftwareConfigParamGroup] = None
     validation: Optional[RUNWValidationParamGroup] = None
 
     unw_phs_img: Optional[RUNWPhaseImageParamGroup] = None
@@ -1854,6 +1902,11 @@ class RUNWRootParamGroup(RootParamGroup):
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
                 param_grp_cls_obj=RUNWProductPathGroupParamGroup,
+            ),
+            Grp(
+                flag_param_grp_req=flag_any_workflows_true,
+                root_param_grp_attr_name="software_config",
+                param_grp_cls_obj=RUNWSoftwareConfigParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -1912,6 +1965,7 @@ class RUNWRootParamGroup(RootParamGroup):
             "input_f": RUNWInputFileGroupParamGroup,
             "prodpath": RUNWProductPathGroupParamGroup,
             "workflows": RUNWWorkflowsParamGroup,
+            "software_config": RUNWSoftwareConfigParamGroup,
             "validation": RUNWValidationParamGroup,
             "unw_phs_img": RUNWPhaseImageParamGroup,
             "coh_mag": RUNWCohMagLayerParamGroup,
@@ -1944,6 +1998,8 @@ class GUNWRootParamGroup(RootParamGroup):
         Input File Group parameters.
     prodpath : GUNWProductPathGroupParamGroup or None, optional
         Product Path Group parameters.
+    software_config : GUNWSoftwareConfigParamGroup or None, optional
+        General QA Software Configuration Group parameters
     validation : GUNWValidationParamGroup or None, optional
         Validation Group parameters for QA
     unw_phs_img : GUNWPhaseImageParamGroup or None, optional
@@ -1973,6 +2029,7 @@ class GUNWRootParamGroup(RootParamGroup):
     # Shared parameters
     input_f: Optional[GUNWInputFileGroupParamGroup] = None
     prodpath: Optional[GUNWProductPathGroupParamGroup] = None
+    software_config: Optional[GUNWSoftwareConfigParamGroup] = None
     validation: Optional[GUNWValidationParamGroup] = None
 
     unw_phs_img: Optional[GUNWPhaseImageParamGroup] = None
@@ -2003,6 +2060,11 @@ class GUNWRootParamGroup(RootParamGroup):
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
                 param_grp_cls_obj=GUNWProductPathGroupParamGroup,
+            ),
+            Grp(
+                flag_param_grp_req=flag_any_workflows_true,
+                root_param_grp_attr_name="software_config",
+                param_grp_cls_obj=GUNWSoftwareConfigParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -2066,6 +2128,7 @@ class GUNWRootParamGroup(RootParamGroup):
             "input_f": GUNWInputFileGroupParamGroup,
             "prodpath": GUNWProductPathGroupParamGroup,
             "workflows": GUNWWorkflowsParamGroup,
+            "software_config": GUNWSoftwareConfigParamGroup,
             "validation": GUNWValidationParamGroup,
             "unw_phs_img": GUNWPhaseImageParamGroup,
             "wrapped_igram": GUNWWrappedIgramParamGroup,
@@ -2099,6 +2162,8 @@ class ROFFRootParamGroup(RootParamGroup):
         Input File Group parameters.
     prodpath : ROFFProductPathGroupParamGroup or None, optional
         Product Path Group parameters.
+    software_config : ROFFSoftwareConfigParamGroup or None, optional
+        General QA Software Configuration Group parameters
     validation : ROFFValidationParamGroup or None, optional
         Validation Group parameters for QA
     az_rng_offsets : ROFFAzAndRangeOffsetsParamGroup or None, optional
@@ -2118,6 +2183,7 @@ class ROFFRootParamGroup(RootParamGroup):
     # Shared parameters
     input_f: Optional[ROFFInputFileGroupParamGroup] = None
     prodpath: Optional[ROFFProductPathGroupParamGroup] = None
+    software_config: Optional[ROFFSoftwareConfigParamGroup] = None
     validation: Optional[ROFFValidationParamGroup] = None
 
     az_rng_offsets: Optional[ROFFAzAndRangeOffsetsParamGroup] = None
@@ -2144,6 +2210,11 @@ class ROFFRootParamGroup(RootParamGroup):
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
                 param_grp_cls_obj=ROFFProductPathGroupParamGroup,
+            ),
+            Grp(
+                flag_param_grp_req=flag_any_workflows_true,
+                root_param_grp_attr_name="software_config",
+                param_grp_cls_obj=ROFFSoftwareConfigParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -2187,6 +2258,7 @@ class ROFFRootParamGroup(RootParamGroup):
             "input_f": ROFFInputFileGroupParamGroup,
             "prodpath": ROFFProductPathGroupParamGroup,
             "workflows": ROFFWorkflowsParamGroup,
+            "software_config": ROFFSoftwareConfigParamGroup,
             "validation": ROFFValidationParamGroup,
             "az_rng_offsets": ROFFAzAndRangeOffsetsParamGroup,
             "quiver": ROFFQuiverParamGroup,
@@ -2216,6 +2288,8 @@ class GOFFRootParamGroup(RootParamGroup):
         Input File Group parameters.
     prodpath : GOFFProductPathGroupParamGroup or None, optional
         Product Path Group parameters.
+    software_config : GOFFSoftwareConfigParamGroup or None, optional
+        General QA Software Configuration Group parameters
     validation : VerificationGroupParamGroup or None, optional
         Validation Group parameters for QA
     az_rng_offsets : GOFFAzAndRangeOffsetsParamGroup or None, optional
@@ -2235,6 +2309,7 @@ class GOFFRootParamGroup(RootParamGroup):
     # Shared parameters
     input_f: Optional[GOFFInputFileGroupParamGroup] = None
     prodpath: Optional[GOFFProductPathGroupParamGroup] = None
+    software_config: Optional[GOFFSoftwareConfigParamGroup] = None
     validation: Optional[GOFFValidationParamGroup] = None
 
     az_rng_offsets: Optional[GOFFAzAndRangeOffsetsParamGroup] = None
@@ -2261,6 +2336,11 @@ class GOFFRootParamGroup(RootParamGroup):
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
                 param_grp_cls_obj=GOFFProductPathGroupParamGroup,
+            ),
+            Grp(
+                flag_param_grp_req=flag_any_workflows_true,
+                root_param_grp_attr_name="software_config",
+                param_grp_cls_obj=GOFFSoftwareConfigParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -2304,6 +2384,7 @@ class GOFFRootParamGroup(RootParamGroup):
             "input_f": GOFFInputFileGroupParamGroup,
             "prodpath": GOFFProductPathGroupParamGroup,
             "workflows": GOFFWorkflowsParamGroup,
+            "software_config": GOFFSoftwareConfigParamGroup,
             "validation": GOFFValidationParamGroup,
             "az_rng_offsets": GOFFAzAndRangeOffsetsParamGroup,
             "quiver": GOFFQuiverParamGroup,

--- a/src/nisarqa/parameters/nisar_params.py
+++ b/src/nisarqa/parameters/nisar_params.py
@@ -1104,7 +1104,7 @@ class ScratchProductPathGroupParamGroup(ProductPathGroupParamGroup):
         default="./scratch",
         metadata={
             "yaml_attrs": YamlAttrs(
-                name="`scratch_path`",
+                name="scratch_path",
                 descr="""Directory where QA software may write temporary data.
                 If the directory does not exist, it will be created.
                 Because this scratch directory might be shared with e.g. ISCE3

--- a/src/nisarqa/parameters/nisar_params.py
+++ b/src/nisarqa/parameters/nisar_params.py
@@ -1052,17 +1052,31 @@ class ProductPathGroupParamGroup(YamlParamGroup):
         },
     )
 
+    scratch_dir: str | os.PathLike = field(
+        default="./qa_scratch",
+        metadata={
+            "yaml_attrs": YamlAttrs(
+                name="scratch_path",
+                descr="""Directory where SAS can write temporary data.""",
+            )
+        },
+    )
+
     def __post_init__(self):
         # VALIDATE INPUTS
 
-        if not isinstance(self.qa_output_dir, (str, os.PathLike)):
-            raise TypeError(f"`qa_output_dir` must be path-like")
+        for dir_name, dir, dir_type in (
+            ("qa_output_dir", self.qa_output_dir, "output"),
+            ("scratch_dir", self.scratch_dir, "scratch"),
+        ):
+            if not isinstance(dir, (str, os.PathLike)):
+                raise TypeError(f"`{dir_name}` must be path-like")
 
-        # If this directory does not exist, make it.
-        if not os.path.isdir(self.qa_output_dir):
-            log = nisarqa.get_logger()
-            log.info(f"Creating QA output directory: {self.qa_output_dir}")
-            os.makedirs(self.qa_output_dir, exist_ok=True)
+            # If this directory does not exist, make it.
+            if not os.path.isdir(dir):
+                log = nisarqa.get_logger()
+                log.info(f"Creating QA {dir_type} directory: {dir}")
+                os.makedirs(dir, exist_ok=True)
 
     @staticmethod
     def get_path_to_group_in_runconfig():

--- a/src/nisarqa/parameters/nisar_params.py
+++ b/src/nisarqa/parameters/nisar_params.py
@@ -5,13 +5,13 @@ import dataclasses
 import io
 import os
 import sys
+import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field, fields
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, ClassVar, Optional, Type, Union
-from datetime import datetime, timezone
-import uuid
 
 import h5py
 from ruamel.yaml import YAML, CommentedMap, CommentedSeq

--- a/src/nisarqa/parameters/nisar_params.py
+++ b/src/nisarqa/parameters/nisar_params.py
@@ -5,11 +5,9 @@ import dataclasses
 import io
 import os
 import sys
-import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field, fields
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, ClassVar, Optional, Type, Union
 
@@ -1043,13 +1041,12 @@ class ProductPathGroupParamGroup(YamlParamGroup):
         Filepath to the output directory to store NISAR QA output files.
         If the directory does not exist, it will be created.
         Defaults to './qa'
-    scratch_dir : path-like, optional
-        Directory where QA software may write temporary data.
+    scratch_dir_parent : path-like, optional
+        Directory where software may write temporary data.
         If the directory does not exist, it will be created.
         Because this scratch directory might be shared with e.g. ISCE3
         science product SASes, QA will create a uniquely-named
-        directory inside `scratch_path` for any QA scratch files.
-        Provided `scratch_dir` argument will be converted to a Path object.
+        directory inside `scratch_dir_parent` for any QA scratch files.
         Defaults to './scratch'
     """
 
@@ -1064,12 +1061,12 @@ class ProductPathGroupParamGroup(YamlParamGroup):
         },
     )
 
-    scratch_dir: str | os.PathLike = field(
+    scratch_dir_parent: str | os.PathLike = field(
         default="./scratch",
         metadata={
             "yaml_attrs": YamlAttrs(
                 name="scratch_path",
-                descr="""Directory where QA software may write temporary data.
+                descr="""Directory where software may write temporary data.
                 If the directory does not exist, it will be created.
                 Because this scratch directory might be shared with e.g. ISCE3
                 science product SASes, QA will create a uniquely-named
@@ -1081,35 +1078,16 @@ class ProductPathGroupParamGroup(YamlParamGroup):
     def __post_init__(self):
         # VALIDATE INPUTS
 
-        if not isinstance(self.qa_output_dir, (str, os.PathLike)):
-            raise TypeError(f"`qa_output_dir` must be path-like")
+        for param_name in ("qa_output_dir", "scratch_dir_parent"):
+            val = getattr(self, param_name)
+            if not isinstance(val, (str, os.PathLike)):
+                raise TypeError(f"`{param_name}` must be path-like")
 
-        # If this directory does not exist, make it.
-        if not os.path.isdir(self.qa_output_dir):
-            log = nisarqa.get_logger()
-            log.info(f"Creating QA output directory: {self.qa_output_dir}")
-            os.makedirs(self.qa_output_dir, exist_ok=True)
-
-        if not isinstance(self.scratch_dir, (str, os.PathLike)):
-            raise TypeError(f"`scratch_dir` must be path-like")
-
-        # Update the path to have a QA subdirectory, and make it uniquely-named
-        utc_now = datetime.now(timezone.utc)
-        # The colon character `:` is not advised for POSIX paths
-        utc_now = utc_now.strftime("%Y-%m-%dT%Hh%Mm%SsZ")
-
-        scratchdir = (
-            Path(self.scratch_dir) / f"qa_scratch-{utc_now}-{uuid.uuid4()}"
-        )
-        object.__setattr__(self, "scratch_dir", scratchdir)
-
-        # Note: Unlike the output directory, do not create the scratch
-        # directory here in the `__post_init__()`. The output directory should
-        # not need to be deleted by QA SAS, whereas the scratch directory
-        # could be deleted (per related user runconfig options.)
-        # Instead, use an e.g. context manager or other method to ensure that
-        # the scratch directory is created and (possibly) deleted per
-        # the user's request.
+            # If this directory does not exist, make it.
+            if not os.path.isdir(val):
+                log = nisarqa.get_logger()
+                log.info(f"Creating {param_name} directory: '{val}'")
+                os.makedirs(val, exist_ok=True)
 
     @staticmethod
     def get_path_to_group_in_runconfig():
@@ -1128,9 +1106,9 @@ class SoftwareConfigParamGroup(YamlParamGroup):
         False to always read data directly from the input file.
         Generally, enabling caching should reduce runtime.
         Defaults to True.
-    delete_scratch_dir : bool, optional
-        True to delete the nested QA scratch directory
-        from inside `scratch_path` when QA SAS is finished.
+    delete_scratch_files : bool, optional
+        True to delete the nested QA scratch directory and its contents
+        from inside `scratch_dir_parent` when QA SAS is finished.
         Defaults to True.
     """
 
@@ -1149,13 +1127,13 @@ class SoftwareConfigParamGroup(YamlParamGroup):
     # For NISAR mission operations, the scratch directory parameter will be
     # shared by QA with the L1/L2 ISCE3 Science Data product SASes.
     # Those SASes do not delete the scratch directory, and QA should not either.
-    delete_scratch_dir: bool = field(
+    delete_scratch_files: bool = field(
         default=True,
         metadata={
             "yaml_attrs": YamlAttrs(
-                name="delete_qa_scratch_dir",
-                descr="""True to delete the nested QA scratch directory 
-                in `scratch_path` when QA SAS is finished.""",
+                name="delete_qa_scratch_files",
+                descr="""True to delete the nested QA scratch directory in
+                `scratch_path` and its contents when QA SAS is finished.""",
             )
         },
     )
@@ -1165,8 +1143,8 @@ class SoftwareConfigParamGroup(YamlParamGroup):
         if not isinstance(self.use_cache, bool):
             raise TypeError(f"`{self.use_cache=}`, must be bool.")
 
-        if not isinstance(self.delete_scratch_dir, bool):
-            raise TypeError(f"`{self.delete_scratch_dir=}`, must be bool.")
+        if not isinstance(self.delete_scratch_files, bool):
+            raise TypeError(f"`{self.delete_scratch_files=}`, must be bool.")
 
     @staticmethod
     def get_path_to_group_in_runconfig():

--- a/src/nisarqa/parameters/nisar_params.py
+++ b/src/nisarqa/parameters/nisar_params.py
@@ -15,6 +15,7 @@ import h5py
 from ruamel.yaml import YAML, CommentedMap, CommentedSeq
 
 import nisarqa
+from nisarqa.utils.typing import RootParamGroupT, RunConfigDict
 
 objects_to_skip = nisarqa.get_all(name=__name__)
 
@@ -1615,10 +1616,10 @@ class RootParamGroup(ABC):
 
     @classmethod
     def from_runconfig_dict(
-        cls: type[nisarqa.typing.RootParamGroupT],
-        user_rncfg: nisarqa.typing.RunConfigDict,
+        cls: type[RootParamGroupT],
+        user_rncfg: RunConfigDict,
         product_type: str,
-    ) -> nisarqa.typing.RootParamGroupT:
+    ) -> RootParamGroupT:
         """
         Build a *RootParamGroup for `product_type` from a QA runconfig dict.
 
@@ -1797,10 +1798,10 @@ class RootParamGroup(ABC):
 
     @classmethod
     def from_runconfig_file(
-        cls: type[nisarqa.typing.RootParamGroupT],
+        cls: type[RootParamGroupT],
         runconfig_yaml: str | os.PathLike,
         product_type: str,
-    ) -> nisarqa.typing.RootParamGroupT:
+    ) -> RootParamGroupT:
         """
         Get a *RootParamGroup for `product_type` from a QA Runconfig YAML file.
 

--- a/src/nisarqa/parameters/rslc_caltools_params.py
+++ b/src/nisarqa/parameters/rslc_caltools_params.py
@@ -1022,7 +1022,6 @@ class RSLCRootParamGroup(RootParamGroup):
 
     # Overwrite parent's attributes b/c new type
     workflows: RSLCWorkflowsParamGroup
-    prodpath: ProductPathGroupParamGroup = None
 
     # QA parameters
     backscatter_img: Optional[BackscatterImageParamGroup] = None

--- a/src/nisarqa/parameters/rslc_caltools_params.py
+++ b/src/nisarqa/parameters/rslc_caltools_params.py
@@ -15,8 +15,9 @@ from nisarqa import (
     HDF5Attrs,
     HDF5ParamGroup,
     InputFileGroupParamGroup,
-    ProductPathGroupParamGroup,
-    RootParamGroup,
+    ScratchProductPathGroupParamGroup,
+    SoftwareConfigGroupParamGroup,
+    NonInsarRootParamGroup,
     RSLCPointTargetAnalyzerParamGroup,
     ValidationGroupParamGroup,
     WorkflowsParamGroup,
@@ -980,7 +981,7 @@ class AzimuthSpectraParamGroup(YamlParamGroup, HDF5ParamGroup):
 
 
 @dataclass
-class RSLCRootParamGroup(RootParamGroup):
+class RSLCRootParamGroup(NonInsarRootParamGroup):
     """
     Dataclass of all *ParamGroup objects to process QA for NISAR RSLC products.
 
@@ -997,8 +998,10 @@ class RSLCRootParamGroup(RootParamGroup):
         RSLC QA Workflows parameters
     input_f : InputFileGroupParamGroup or None, optional
         Input File Group parameters for RSLC QA
-    prodpath : ProductPathGroupParamGroup or None, optional
+    prodpath : ScratchProductPathGroupParamGroup or None, optional
         Product Path Group parameters for RSLC QA
+    software_config : SoftwareConfigParamGroup or None, optional
+        General QA Software Configuration Group parameters
     validation : ValidationGroupParamGroup or None, optional
         Validation Group parameters for QA
     backscatter_img : BackscatterImageParamGroup or None, optional
@@ -1017,10 +1020,9 @@ class RSLCRootParamGroup(RootParamGroup):
         Point Target Analyzer group parameters for RSLC QA-Caltools
     """
 
-    # Shared parameters
-    workflows: (
-        RSLCWorkflowsParamGroup  # overwrite parent's `workflows` b/c new type
-    )
+    # Overwrite parent's attributes b/c new type
+    workflows: RSLCWorkflowsParamGroup
+    prodpath: ScratchProductPathGroupParamGroup = None
 
     # QA parameters
     backscatter_img: Optional[BackscatterImageParamGroup] = None
@@ -1115,7 +1117,9 @@ class RSLCRootParamGroup(RootParamGroup):
 
     @staticmethod
     def get_mapping_of_workflows2param_grps(workflows):
-        Grp = RootParamGroup.ReqParamGrp  # class object for our named tuple
+        Grp = (
+            NonInsarRootParamGroup.ReqParamGrp
+        )  # class object for our named tuple
 
         flag_any_workflows_true = any(
             [getattr(workflows, field.name) for field in fields(workflows)]
@@ -1130,7 +1134,12 @@ class RSLCRootParamGroup(RootParamGroup):
             Grp(
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
-                param_grp_cls_obj=ProductPathGroupParamGroup,
+                param_grp_cls_obj=ScratchProductPathGroupParamGroup,
+            ),
+            Grp(
+                flag_param_grp_req=flag_any_workflows_true,
+                root_param_grp_attr_name="software_config",
+                param_grp_cls_obj=SoftwareConfigGroupParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -1183,8 +1192,9 @@ class RSLCRootParamGroup(RootParamGroup):
         return {
             "input_f": InputFileGroupParamGroup,
             "anc_files": DynamicAncillaryFileParamGroup,
-            "prodpath": ProductPathGroupParamGroup,
+            "prodpath": ScratchProductPathGroupParamGroup,
             "workflows": RSLCWorkflowsParamGroup,
+            "software_config": SoftwareConfigGroupParamGroup,
             "validation": ValidationGroupParamGroup,
             "backscatter_img": BackscatterImageParamGroup,
             "histogram": HistogramParamGroup,

--- a/src/nisarqa/parameters/rslc_caltools_params.py
+++ b/src/nisarqa/parameters/rslc_caltools_params.py
@@ -15,10 +15,10 @@ from nisarqa import (
     HDF5Attrs,
     HDF5ParamGroup,
     InputFileGroupParamGroup,
-    NonInsarRootParamGroup,
+    ProductPathGroupParamGroup,
+    RootParamGroup,
     RSLCPointTargetAnalyzerParamGroup,
-    ScratchProductPathGroupParamGroup,
-    SoftwareConfigGroupParamGroup,
+    SoftwareConfigParamGroup,
     ValidationGroupParamGroup,
     WorkflowsParamGroup,
     YamlAttrs,
@@ -981,7 +981,7 @@ class AzimuthSpectraParamGroup(YamlParamGroup, HDF5ParamGroup):
 
 
 @dataclass
-class RSLCRootParamGroup(NonInsarRootParamGroup):
+class RSLCRootParamGroup(RootParamGroup):
     """
     Dataclass of all *ParamGroup objects to process QA for NISAR RSLC products.
 
@@ -998,7 +998,7 @@ class RSLCRootParamGroup(NonInsarRootParamGroup):
         RSLC QA Workflows parameters
     input_f : InputFileGroupParamGroup or None, optional
         Input File Group parameters for RSLC QA
-    prodpath : ScratchProductPathGroupParamGroup or None, optional
+    prodpath : ProductPathGroupParamGroup or None, optional
         Product Path Group parameters for RSLC QA
     software_config : SoftwareConfigParamGroup or None, optional
         General QA Software Configuration Group parameters
@@ -1022,7 +1022,7 @@ class RSLCRootParamGroup(NonInsarRootParamGroup):
 
     # Overwrite parent's attributes b/c new type
     workflows: RSLCWorkflowsParamGroup
-    prodpath: ScratchProductPathGroupParamGroup = None
+    prodpath: ProductPathGroupParamGroup = None
 
     # QA parameters
     backscatter_img: Optional[BackscatterImageParamGroup] = None
@@ -1117,9 +1117,7 @@ class RSLCRootParamGroup(NonInsarRootParamGroup):
 
     @staticmethod
     def get_mapping_of_workflows2param_grps(workflows):
-        Grp = (
-            NonInsarRootParamGroup.ReqParamGrp
-        )  # class object for our named tuple
+        Grp = RootParamGroup.ReqParamGrp  # class object for our named tuple
 
         flag_any_workflows_true = any(
             [getattr(workflows, field.name) for field in fields(workflows)]
@@ -1134,12 +1132,12 @@ class RSLCRootParamGroup(NonInsarRootParamGroup):
             Grp(
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
-                param_grp_cls_obj=ScratchProductPathGroupParamGroup,
+                param_grp_cls_obj=ProductPathGroupParamGroup,
             ),
             Grp(
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="software_config",
-                param_grp_cls_obj=SoftwareConfigGroupParamGroup,
+                param_grp_cls_obj=SoftwareConfigParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -1192,9 +1190,9 @@ class RSLCRootParamGroup(NonInsarRootParamGroup):
         return {
             "input_f": InputFileGroupParamGroup,
             "anc_files": DynamicAncillaryFileParamGroup,
-            "prodpath": ScratchProductPathGroupParamGroup,
+            "prodpath": ProductPathGroupParamGroup,
             "workflows": RSLCWorkflowsParamGroup,
-            "software_config": SoftwareConfigGroupParamGroup,
+            "software_config": SoftwareConfigParamGroup,
             "validation": ValidationGroupParamGroup,
             "backscatter_img": BackscatterImageParamGroup,
             "histogram": HistogramParamGroup,

--- a/src/nisarqa/parameters/rslc_caltools_params.py
+++ b/src/nisarqa/parameters/rslc_caltools_params.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numbers
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field, fields, replace
-from typing import ClassVar, Optional, Type, Union
+from typing import ClassVar, Optional, Union
 
 import numpy as np
 from matplotlib.colors import to_rgba
@@ -15,10 +15,10 @@ from nisarqa import (
     HDF5Attrs,
     HDF5ParamGroup,
     InputFileGroupParamGroup,
-    ScratchProductPathGroupParamGroup,
-    SoftwareConfigGroupParamGroup,
     NonInsarRootParamGroup,
     RSLCPointTargetAnalyzerParamGroup,
+    ScratchProductPathGroupParamGroup,
+    SoftwareConfigGroupParamGroup,
     ValidationGroupParamGroup,
     WorkflowsParamGroup,
     YamlAttrs,

--- a/src/nisarqa/products/caltools.py
+++ b/src/nisarqa/products/caltools.py
@@ -152,7 +152,7 @@ def run_abscal_single_freq_pol(
     kwds["pthresh"] = kwds.pop("power_threshold")
 
     # Create a scratch file to store the JSON output of the tool.
-    scratch_dir = nisarqa.scratch_directory(dir_=scratch_dir, delete=False)
+    scratch_dir = nisarqa.make_scratch_directory(dir_=scratch_dir)
     tmpfile = nisarqa.make_scratch_file(
         dir_=scratch_dir, prefix=f"abscal-{freq}-{pol}-", suffix=".json"
     )
@@ -480,7 +480,7 @@ def run_rslc_pta_single_freq_pol(
     kwds = asdict(pta_params)
 
     # Create a scratch file to store the JSON output of the tool.
-    scratch_dir = nisarqa.scratch_directory(dir_=scratch_dir, delete=False)
+    scratch_dir = nisarqa.make_scratch_directory(dir_=scratch_dir)
     tmpfile = nisarqa.make_scratch_file(
         dir_=scratch_dir, prefix=f"pta-{freq}-{pol}-", suffix=".json"
     )
@@ -583,7 +583,7 @@ def run_gslc_pta_single_freq_pol(
     kwds = asdict(pta_params)
 
     # Create a scratch file to store the JSON output of the tool.
-    scratch_dir = nisarqa.scratch_directory(dir_=scratch_dir, delete=False)
+    scratch_dir = nisarqa.make_scratch_directory(dir_=scratch_dir)
     tmpfile = nisarqa.make_scratch_file(
         dir_=scratch_dir, prefix=f"pta-{freq}-{pol}-", suffix=".json"
     )

--- a/src/nisarqa/products/caltools.py
+++ b/src/nisarqa/products/caltools.py
@@ -113,11 +113,13 @@ def run_abscal_single_freq_pol(
         A dataclass containing the parameters for processing
         and outputting the Absolute Calibration Factor workflow.
     scratch_dir : path-like or None, optional
-        Existing directory where QA software may write temporary data.
-        Temporary files are not guaranteed to be deleted upon exiting.
-        If `scratch_dir` is a path-like object, it should already exist.
-        If None, a temporary directory will be created as though
-        by `tempfile.mkdtemp()`.
+        Directory where QA software may write memory-mapped files.
+        If `cache_dir` is a path-like object, a directory will be created
+        at the specified file system path if it did not already exist.
+        If `cache_dir` is None, a temporary directory will be created as
+        though by `tempfile.mkdtemp()`.
+        The user is responsible for deleting the cache directory and its
+        contents when done with it.
         Defaults to None.
 
     Returns
@@ -149,7 +151,8 @@ def run_abscal_single_freq_pol(
     assert "pthresh" not in kwds
     kwds["pthresh"] = kwds.pop("power_threshold")
 
-    # Create a temporary file to store the JSON output of the tool.
+    # Create a scratch file to store the JSON output of the tool.
+    scratch_dir = nisarqa.scratch_directory(dir_=scratch_dir, delete=False)
     tmpfile = nisarqa.make_scratch_file(
         dir_=scratch_dir, prefix=f"abscal-{freq}-{pol}-", suffix=".json"
     )
@@ -172,7 +175,8 @@ def run_abscal_single_freq_pol(
         return []
     else:
         with open(tmpfile, "r") as f:
-            return json.load(f)
+            data = json.load(f)
+        return data
 
 
 def populate_abscal_hdf5_output(
@@ -313,11 +317,13 @@ def run_abscal_tool(
         Filename (with path) for output STATS.h5 file. This is where
         outputs from the CalTool should be stored.
     scratch_dir : path-like or None, optional
-        Existing directory where QA software may write temporary data.
-        Temporary files are not guaranteed to be deleted upon exiting.
-        If `scratch_dir` is a path-like object, it should already exist.
-        If None, a temporary directory will be created as though
-        by `tempfile.mkdtemp()`.
+        Directory where QA software may write memory-mapped files.
+        If `cache_dir` is a path-like object, a directory will be created
+        at the specified file system path if it did not already exist.
+        If `cache_dir` is None, a temporary directory will be created as
+        though by `tempfile.mkdtemp()`.
+        The user is responsible for deleting the cache directory and its
+        contents when done with it.
         Defaults to None.
     """
     for freq in rslc.freqs:
@@ -439,11 +445,13 @@ def run_rslc_pta_single_freq_pol(
         A dataclass containing the parameters for processing
         and outputting the Point Target Analyzer workflow.
     scratch_dir : path-like or None, optional
-        Existing directory where QA software may write temporary data.
-        Temporary files are not guaranteed to be deleted upon exiting.
-        If `scratch_dir` is a path-like object, it should already exist.
-        If None, a temporary directory will be created as though
-        by `tempfile.mkdtemp()`.
+        Directory where QA software may write memory-mapped files.
+        If `cache_dir` is a path-like object, a directory will be created
+        at the specified file system path if it did not already exist.
+        If `cache_dir` is None, a temporary directory will be created as
+        though by `tempfile.mkdtemp()`.
+        The user is responsible for deleting the cache directory and its
+        contents when done with it.
         Defaults to None.
 
     Returns
@@ -471,7 +479,8 @@ def run_rslc_pta_single_freq_pol(
     # code will need to be updated accordingly.
     kwds = asdict(pta_params)
 
-    # Create a temporary file to store the JSON output of the tool.
+    # Create a scratch file to store the JSON output of the tool.
+    scratch_dir = nisarqa.scratch_directory(dir_=scratch_dir, delete=False)
     tmpfile = nisarqa.make_scratch_file(
         dir_=scratch_dir, prefix=f"pta-{freq}-{pol}-", suffix=".json"
     )
@@ -493,7 +502,8 @@ def run_rslc_pta_single_freq_pol(
         return []
     else:
         with open(tmpfile, "r") as f:
-            return json.load(f)
+            data = json.load(f)
+        return data
 
 
 def run_gslc_pta_single_freq_pol(
@@ -538,11 +548,13 @@ def run_gslc_pta_single_freq_pol(
         supplied), the PTA tool will attempt to un-flatten using the reference
         ellipsoid, which may produce less accurate results. Defaults to None.
     scratch_dir : path-like or None, optional
-        Existing directory where QA software may write temporary data.
-        Temporary files are not guaranteed to be deleted upon exiting.
-        If `scratch_dir` is a path-like object, it should already exist.
-        If None, a temporary directory will be created as though
-        by `tempfile.mkdtemp()`.
+        Directory where QA software may write memory-mapped files.
+        If `cache_dir` is a path-like object, a directory will be created
+        at the specified file system path if it did not already exist.
+        If `cache_dir` is None, a temporary directory will be created as
+        though by `tempfile.mkdtemp()`.
+        The user is responsible for deleting the cache directory and its
+        contents when done with it.
         Defaults to None.
 
     Returns
@@ -570,7 +582,8 @@ def run_gslc_pta_single_freq_pol(
     # QA code will need to be updated accordingly.
     kwds = asdict(pta_params)
 
-    # Create a temporary file to store the JSON output of the tool.
+    # Create a scratch file to store the JSON output of the tool.
+    scratch_dir = nisarqa.scratch_directory(dir_=scratch_dir, delete=False)
     tmpfile = nisarqa.make_scratch_file(
         dir_=scratch_dir, prefix=f"pta-{freq}-{pol}-", suffix=".json"
     )
@@ -593,7 +606,8 @@ def run_gslc_pta_single_freq_pol(
         return []
     else:
         with open(tmpfile, "r") as f:
-            return json.load(f)
+            data = json.load(f)
+        return data
 
 
 def populate_pta_hdf5_output(
@@ -932,11 +946,13 @@ def run_rslc_pta_tool(
         Filename (with path) for output STATS.h5 file. This is where
         outputs from the CalTool should be stored.
     scratch_dir : path-like or None, optional
-        Existing directory where QA software may write temporary data.
-        Temporary files are not guaranteed to be deleted upon exiting.
-        If `scratch_dir` is a path-like object, it should already exist.
-        If None, a temporary directory will be created as though
-        by `tempfile.mkdtemp()`.
+        Directory where QA software may write memory-mapped files.
+        If `cache_dir` is a path-like object, a directory will be created
+        at the specified file system path if it did not already exist.
+        If `cache_dir` is None, a temporary directory will be created as
+        though by `tempfile.mkdtemp()`.
+        The user is responsible for deleting the cache directory and its
+        contents when done with it.
         Defaults to None.
     """
 
@@ -1040,11 +1056,13 @@ def run_gslc_pta_tool(
         Filename (with path) for output STATS.h5 file. This is where
         outputs from the CalTool should be stored.
     scratch_dir : path-like or None, optional
-        Existing directory where QA software may write temporary data.
-        Temporary files are not guaranteed to be deleted upon exiting.
-        If `scratch_dir` is a path-like object, it should already exist.
-        If None, a temporary directory will be created as though
-        by `tempfile.mkdtemp()`.
+        Directory where QA software may write memory-mapped files.
+        If `cache_dir` is a path-like object, a directory will be created
+        at the specified file system path if it did not already exist.
+        If `cache_dir` is None, a temporary directory will be created as
+        though by `tempfile.mkdtemp()`.
+        The user is responsible for deleting the cache directory and its
+        contents when done with it.
         Defaults to None.
     """
 

--- a/src/nisarqa/products/caltools.py
+++ b/src/nisarqa/products/caltools.py
@@ -172,8 +172,7 @@ def run_abscal_single_freq_pol(
         return []
     else:
         with open(tmpfile, "r") as f:
-            data = json.load(f)
-        return data
+            return json.load(f)
 
 
 def populate_abscal_hdf5_output(
@@ -494,8 +493,7 @@ def run_rslc_pta_single_freq_pol(
         return []
     else:
         with open(tmpfile, "r") as f:
-            data = json.load(f)
-        return data
+            return json.load(f)
 
 
 def run_gslc_pta_single_freq_pol(
@@ -595,8 +593,7 @@ def run_gslc_pta_single_freq_pol(
         return []
     else:
         with open(tmpfile, "r") as f:
-            data = json.load(f)
-        return data
+            return json.load(f)
 
 
 def populate_pta_hdf5_output(

--- a/src/nisarqa/products/caltools.py
+++ b/src/nisarqa/products/caltools.py
@@ -85,7 +85,6 @@ def run_abscal_single_freq_pol(
     freq: str,
     pol: str,
     abscal_params: AbsCalParamGroup,
-    scratch_dir: str | os.PathLike | None = None,
 ) -> list[dict[str, Any]]:
     """
     Run the absolute radiometric calibration (AbsCal) tool.
@@ -112,15 +111,6 @@ def run_abscal_single_freq_pol(
     abscal_params : AbsCalParamGroup
         A dataclass containing the parameters for processing
         and outputting the Absolute Calibration Factor workflow.
-    scratch_dir : path-like or None, optional
-        Directory where QA software may write memory-mapped files.
-        If `cache_dir` is a path-like object, a directory will be created
-        at the specified file system path if it did not already exist.
-        If `cache_dir` is None, a temporary directory will be created as
-        though by `tempfile.mkdtemp()`.
-        The user is responsible for deleting the cache directory and its
-        contents when done with it.
-        Defaults to None.
 
     Returns
     -------
@@ -152,10 +142,7 @@ def run_abscal_single_freq_pol(
     kwds["pthresh"] = kwds.pop("power_threshold")
 
     # Create a scratch file to store the JSON output of the tool.
-    scratch_dir = nisarqa.make_scratch_directory(dir_=scratch_dir)
-    tmpfile = nisarqa.make_scratch_file(
-        dir_=scratch_dir, prefix=f"abscal-{freq}-{pol}-", suffix=".json"
-    )
+    tmpfile = nisarqa.get_global_scratch() / f"abscal-{freq}-{pol}.json"
 
     # Run AbsCal tool.
     estimate_abscal_factor.main(
@@ -298,7 +285,6 @@ def run_abscal_tool(
     dyn_anc_params: DynamicAncillaryFileParamGroup,
     rslc: nisarqa.RSLC,
     stats_filename: str | os.PathLike,
-    scratch_dir: str | os.PathLike | None = None,
 ) -> None:
     """
     Run the Absolute Calibration Factor workflow.
@@ -316,15 +302,6 @@ def run_abscal_tool(
     stats_filename : path-like
         Filename (with path) for output STATS.h5 file. This is where
         outputs from the CalTool should be stored.
-    scratch_dir : path-like or None, optional
-        Directory where QA software may write memory-mapped files.
-        If `cache_dir` is a path-like object, a directory will be created
-        at the specified file system path if it did not already exist.
-        If `cache_dir` is None, a temporary directory will be created as
-        though by `tempfile.mkdtemp()`.
-        The user is responsible for deleting the cache directory and its
-        contents when done with it.
-        Defaults to None.
     """
     for freq in rslc.freqs:
         # The scattering matrix of a canonical triangular trihedral corner
@@ -343,7 +320,6 @@ def run_abscal_tool(
                     freq=freq,
                     pol=pol,
                     abscal_params=abscal_params,
-                    scratch_dir=scratch_dir,
                 )
             nisarqa.get_logger().info(
                 f"AbsCal Tool for Frequency {freq}, Polarization {pol}"
@@ -417,7 +393,6 @@ def run_rslc_pta_single_freq_pol(
     freq: str,
     pol: str,
     pta_params: RSLCPointTargetAnalyzerParamGroup,
-    scratch_dir: str | os.PathLike | None = None,
 ) -> list[dict[str, Any]]:
     """
     Run the RSLC point target analysis (PTA) tool.
@@ -444,15 +419,6 @@ def run_rslc_pta_single_freq_pol(
     pta_params : RSLCPointTargetAnalyzerParamGroup
         A dataclass containing the parameters for processing
         and outputting the Point Target Analyzer workflow.
-    scratch_dir : path-like or None, optional
-        Directory where QA software may write memory-mapped files.
-        If `cache_dir` is a path-like object, a directory will be created
-        at the specified file system path if it did not already exist.
-        If `cache_dir` is None, a temporary directory will be created as
-        though by `tempfile.mkdtemp()`.
-        The user is responsible for deleting the cache directory and its
-        contents when done with it.
-        Defaults to None.
 
     Returns
     -------
@@ -480,10 +446,8 @@ def run_rslc_pta_single_freq_pol(
     kwds = asdict(pta_params)
 
     # Create a scratch file to store the JSON output of the tool.
-    scratch_dir = nisarqa.make_scratch_directory(dir_=scratch_dir)
-    tmpfile = nisarqa.make_scratch_file(
-        dir_=scratch_dir, prefix=f"pta-{freq}-{pol}-", suffix=".json"
-    )
+    tmpfile = nisarqa.get_global_scratch() / f"abscal-{freq}-{pol}.json"
+
     # Run PTA tool.
     point_target_analysis.process_corner_reflector_csv(
         corner_reflector_csv=corner_reflector_csv,
@@ -514,7 +478,6 @@ def run_gslc_pta_single_freq_pol(
     pol: str,
     pta_params: PointTargetAnalyzerParamGroup,
     dem_file: str | os.PathLike | None = None,
-    scratch_dir: str | os.PathLike | None = None,
 ) -> list[dict[str, Any]]:
     """
     Run the GSLC point target analysis (PTA) tool.
@@ -547,15 +510,6 @@ def run_gslc_pta_single_freq_pol(
         applicable (i.e. if the GSLC was flattened). If None (no DEM is
         supplied), the PTA tool will attempt to un-flatten using the reference
         ellipsoid, which may produce less accurate results. Defaults to None.
-    scratch_dir : path-like or None, optional
-        Directory where QA software may write memory-mapped files.
-        If `cache_dir` is a path-like object, a directory will be created
-        at the specified file system path if it did not already exist.
-        If `cache_dir` is None, a temporary directory will be created as
-        though by `tempfile.mkdtemp()`.
-        The user is responsible for deleting the cache directory and its
-        contents when done with it.
-        Defaults to None.
 
     Returns
     -------
@@ -583,10 +537,8 @@ def run_gslc_pta_single_freq_pol(
     kwds = asdict(pta_params)
 
     # Create a scratch file to store the JSON output of the tool.
-    scratch_dir = nisarqa.make_scratch_directory(dir_=scratch_dir)
-    tmpfile = nisarqa.make_scratch_file(
-        dir_=scratch_dir, prefix=f"pta-{freq}-{pol}-", suffix=".json"
-    )
+    tmpfile = nisarqa.get_global_scratch() / f"abscal-{freq}-{pol}.json"
+
     # Run PTA tool.
     gslc_point_target_analysis.analyze_gslc_point_targets_csv(
         gslc_filename=gslc_hdf5,
@@ -927,7 +879,6 @@ def run_rslc_pta_tool(
     dyn_anc_params: DynamicAncillaryFileParamGroup,
     rslc: nisarqa.RSLC,
     stats_filename: str | os.PathLike,
-    scratch_dir: str | os.PathLike | None = None,
 ) -> None:
     """
     Run the RSLC Point Target Analyzer (PTA) workflow.
@@ -945,15 +896,6 @@ def run_rslc_pta_tool(
     stats_filename : path-like
         Filename (with path) for output STATS.h5 file. This is where
         outputs from the CalTool should be stored.
-    scratch_dir : path-like or None, optional
-        Directory where QA software may write memory-mapped files.
-        If `cache_dir` is a path-like object, a directory will be created
-        at the specified file system path if it did not already exist.
-        If `cache_dir` is None, a temporary directory will be created as
-        though by `tempfile.mkdtemp()`.
-        The user is responsible for deleting the cache directory and its
-        contents when done with it.
-        Defaults to None.
     """
 
     for freq in rslc.freqs:
@@ -973,7 +915,6 @@ def run_rslc_pta_tool(
                     freq=freq,
                     pol=pol,
                     pta_params=pta_params,
-                    scratch_dir=scratch_dir,
                 )
             nisarqa.get_logger().info(
                 f"RSLC PTA Tool for Frequency {freq}, Polarization {pol}"
@@ -1037,7 +978,6 @@ def run_gslc_pta_tool(
     dyn_anc_params: GSLCDynamicAncillaryFileParamGroup,
     gslc: nisarqa.GSLC,
     stats_filename: str | os.PathLike,
-    scratch_dir: str | os.PathLike | None = None,
 ) -> None:
     """
     Run the GSLC Point Target Analyzer (PTA) workflow.
@@ -1055,15 +995,6 @@ def run_gslc_pta_tool(
     stats_filename : path-like
         Filename (with path) for output STATS.h5 file. This is where
         outputs from the CalTool should be stored.
-    scratch_dir : path-like or None, optional
-        Directory where QA software may write memory-mapped files.
-        If `cache_dir` is a path-like object, a directory will be created
-        at the specified file system path if it did not already exist.
-        If `cache_dir` is None, a temporary directory will be created as
-        though by `tempfile.mkdtemp()`.
-        The user is responsible for deleting the cache directory and its
-        contents when done with it.
-        Defaults to None.
     """
 
     for freq in gslc.freqs:
@@ -1084,7 +1015,6 @@ def run_gslc_pta_tool(
                     pol=pol,
                     pta_params=pta_params,
                     dem_file=dyn_anc_params.dem_file,
-                    scratch_dir=scratch_dir,
                 )
             nisarqa.get_logger().info(
                 f"GSLC PTA Tool for Frequency {freq}, Polarization {pol}"

--- a/src/nisarqa/products/caltools.py
+++ b/src/nisarqa/products/caltools.py
@@ -80,6 +80,7 @@ def file_is_empty(filepath: str | os.PathLike) -> bool:
     return os.stat(filepath).st_size == 0
 
 
+@nisarqa.log_function_start_and_stop_time
 def run_abscal_single_freq_pol(
     corner_reflector_csv: str | os.PathLike,
     rslc_hdf5: str | os.PathLike,
@@ -384,6 +385,7 @@ def run_neb_tool(
             # TODO: Step 2: create plots
 
 
+@nisarqa.log_function_start_and_stop_time
 def run_rslc_pta_single_freq_pol(
     corner_reflector_csv: str | os.PathLike,
     rslc_hdf5: str | os.PathLike,
@@ -465,6 +467,7 @@ def run_rslc_pta_single_freq_pol(
             return json.load(tmpfile)
 
 
+@nisarqa.log_function_start_and_stop_time
 def run_gslc_pta_single_freq_pol(
     corner_reflector_csv: str | os.PathLike,
     gslc_hdf5: str | os.PathLike,

--- a/src/nisarqa/products/caltools.py
+++ b/src/nisarqa/products/caltools.py
@@ -80,7 +80,6 @@ def file_is_empty(filepath: str | os.PathLike) -> bool:
     return os.stat(filepath).st_size == 0
 
 
-@nisarqa.log_function_start_and_stop_time
 def run_abscal_single_freq_pol(
     corner_reflector_csv: str | os.PathLike,
     rslc_hdf5: str | os.PathLike,
@@ -385,7 +384,6 @@ def run_neb_tool(
             # TODO: Step 2: create plots
 
 
-@nisarqa.log_function_start_and_stop_time
 def run_rslc_pta_single_freq_pol(
     corner_reflector_csv: str | os.PathLike,
     rslc_hdf5: str | os.PathLike,
@@ -467,7 +465,6 @@ def run_rslc_pta_single_freq_pol(
             return json.load(tmpfile)
 
 
-@nisarqa.log_function_start_and_stop_time
 def run_gslc_pta_single_freq_pol(
     corner_reflector_csv: str | os.PathLike,
     gslc_hdf5: str | os.PathLike,

--- a/src/nisarqa/products/caltools.py
+++ b/src/nisarqa/products/caltools.py
@@ -162,8 +162,7 @@ def run_abscal_single_freq_pol(
         return []
     else:
         with open(tmpfile, "r") as f:
-            data = json.load(f)
-        return data
+            return json.load(f)
 
 
 def populate_abscal_hdf5_output(
@@ -466,8 +465,7 @@ def run_rslc_pta_single_freq_pol(
         return []
     else:
         with open(tmpfile, "r") as f:
-            data = json.load(f)
-        return data
+            return json.load(f)
 
 
 def run_gslc_pta_single_freq_pol(
@@ -558,8 +556,7 @@ def run_gslc_pta_single_freq_pol(
         return []
     else:
         with open(tmpfile, "r") as f:
-            data = json.load(f)
-        return data
+            return json.load(f)
 
 
 def populate_pta_hdf5_output(

--- a/src/nisarqa/products/caltools.py
+++ b/src/nisarqa/products/caltools.py
@@ -142,7 +142,7 @@ def run_abscal_single_freq_pol(
     kwds["pthresh"] = kwds.pop("power_threshold")
 
     # Create a scratch file to store the JSON output of the tool.
-    tmpfile = nisarqa.get_global_scratch() / f"abscal-{freq}-{pol}.json"
+    tmpfile = nisarqa.get_global_scratch_dir() / f"abscal-{freq}-{pol}.json"
 
     # Run AbsCal tool.
     estimate_abscal_factor.main(
@@ -445,7 +445,7 @@ def run_rslc_pta_single_freq_pol(
     kwds = asdict(pta_params)
 
     # Create a scratch file to store the JSON output of the tool.
-    tmpfile = nisarqa.get_global_scratch() / f"abscal-{freq}-{pol}.json"
+    tmpfile = nisarqa.get_global_scratch_dir() / f"abscal-{freq}-{pol}.json"
 
     # Run PTA tool.
     point_target_analysis.process_corner_reflector_csv(
@@ -535,7 +535,7 @@ def run_gslc_pta_single_freq_pol(
     kwds = asdict(pta_params)
 
     # Create a scratch file to store the JSON output of the tool.
-    tmpfile = nisarqa.get_global_scratch() / f"abscal-{freq}-{pol}.json"
+    tmpfile = nisarqa.get_global_scratch_dir() / f"abscal-{freq}-{pol}.json"
 
     # Run PTA tool.
     gslc_point_target_analysis.analyze_gslc_point_targets_csv(

--- a/src/nisarqa/products/gcov.py
+++ b/src/nisarqa/products/gcov.py
@@ -8,7 +8,6 @@ import nisarqa
 objects_to_skip = nisarqa.get_all(name=__name__)
 
 
-@nisarqa.prep_scratch_dir_from_root_params
 def verify_gcov(
     root_params: nisarqa.GCOVRootParamGroup, verbose: bool = False
 ) -> None:
@@ -46,7 +45,6 @@ def verify_gcov(
     report_file = out_dir / root_params.get_report_pdf_filename()
     stats_file = out_dir / root_params.get_stats_h5_filename()
     summary_file = out_dir / root_params.get_summary_csv_filename()
-    scratch_dir = root_params.prodpath.scratch_dir
 
     msg = f"Starting Quality Assurance for input file: {input_file}"
     log.info(msg)
@@ -61,7 +59,6 @@ def verify_gcov(
         product = nisarqa.GCOV(
             filepath=input_file,
             use_cache=root_params.software_config.use_cache,
-            cache_dir=scratch_dir,
             # prime_the_cache=True,  # we analyze all images, so prime the cache
         )
     except:

--- a/src/nisarqa/products/gcov.py
+++ b/src/nisarqa/products/gcov.py
@@ -8,6 +8,7 @@ import nisarqa
 objects_to_skip = nisarqa.get_all(name=__name__)
 
 
+@nisarqa.prep_scratch_dir_from_root_params
 def verify_gcov(
     root_params: nisarqa.GCOVRootParamGroup, verbose: bool = False
 ) -> None:
@@ -45,6 +46,7 @@ def verify_gcov(
     report_file = out_dir / root_params.get_report_pdf_filename()
     stats_file = out_dir / root_params.get_stats_h5_filename()
     summary_file = out_dir / root_params.get_summary_csv_filename()
+    scratch_dir = root_params.prodpath.scratch_dir
 
     msg = f"Starting Quality Assurance for input file: {input_file}"
     log.info(msg)
@@ -56,7 +58,12 @@ def verify_gcov(
     summary = nisarqa.get_summary()
 
     try:
-        product = nisarqa.GCOV(filepath=input_file)
+        product = nisarqa.GCOV(
+            filepath=input_file,
+            use_cache=root_params.software_config.use_cache,
+            cache_dir=scratch_dir,
+            # prime_the_cache=True,  # we analyze all images, so prime the cache
+        )
     except:
         # Input product could not be opened via the product reader.
         summary.check_can_open_input_file(result="FAIL")

--- a/src/nisarqa/products/gslc.py
+++ b/src/nisarqa/products/gslc.py
@@ -8,6 +8,7 @@ import nisarqa
 objects_to_skip = nisarqa.get_all(name=__name__)
 
 
+@nisarqa.prep_scratch_dir_from_root_params
 def verify_gslc(
     root_params: nisarqa.GSLCRootParamGroup, verbose: bool = False
 ) -> None:
@@ -47,6 +48,7 @@ def verify_gslc(
     report_file = out_dir / root_params.get_report_pdf_filename()
     stats_file = out_dir / root_params.get_stats_h5_filename()
     summary_file = out_dir / root_params.get_summary_csv_filename()
+    scratch_dir = root_params.prodpath.scratch_dir
 
     msg = f"Starting Quality Assurance for input file: {input_file}"
     log.info(msg)
@@ -58,7 +60,12 @@ def verify_gslc(
     summary = nisarqa.get_summary()
 
     try:
-        product = nisarqa.GSLC(filepath=input_file)
+        product = nisarqa.GSLC(
+            filepath=input_file,
+            use_cache=root_params.software_config.use_cache,
+            cache_dir=scratch_dir,
+            # prime_the_cache=True,  # we analyze all images, so prime the cache
+        )
     except:
         # Input product could not be opened via the product reader.
         summary.check_can_open_input_file(result="FAIL")

--- a/src/nisarqa/products/gslc.py
+++ b/src/nisarqa/products/gslc.py
@@ -216,6 +216,7 @@ def verify_gslc(
                 dyn_anc_params=root_params.anc_files,
                 gslc=product,
                 stats_filename=stats_file,
+                scratch_dir=scratch_dir,
             )
             log.info(
                 f"Point Target Analyzer CalTool results saved to {stats_file}."

--- a/src/nisarqa/products/gslc.py
+++ b/src/nisarqa/products/gslc.py
@@ -8,7 +8,6 @@ import nisarqa
 objects_to_skip = nisarqa.get_all(name=__name__)
 
 
-@nisarqa.prep_scratch_dir_from_root_params
 def verify_gslc(
     root_params: nisarqa.GSLCRootParamGroup, verbose: bool = False
 ) -> None:
@@ -48,7 +47,6 @@ def verify_gslc(
     report_file = out_dir / root_params.get_report_pdf_filename()
     stats_file = out_dir / root_params.get_stats_h5_filename()
     summary_file = out_dir / root_params.get_summary_csv_filename()
-    scratch_dir = root_params.prodpath.scratch_dir
 
     msg = f"Starting Quality Assurance for input file: {input_file}"
     log.info(msg)
@@ -63,7 +61,6 @@ def verify_gslc(
         product = nisarqa.GSLC(
             filepath=input_file,
             use_cache=root_params.software_config.use_cache,
-            cache_dir=scratch_dir,
             # prime_the_cache=True,  # we analyze all images, so prime the cache
         )
     except:
@@ -216,7 +213,6 @@ def verify_gslc(
                 dyn_anc_params=root_params.anc_files,
                 gslc=product,
                 stats_filename=stats_file,
-                scratch_dir=scratch_dir,
             )
             log.info(
                 f"Point Target Analyzer CalTool results saved to {stats_file}."

--- a/src/nisarqa/products/igram.py
+++ b/src/nisarqa/products/igram.py
@@ -74,6 +74,7 @@ def verify_igram(
     report_file = out_dir / root_params.get_report_pdf_filename()
     stats_file = out_dir / root_params.get_stats_h5_filename()
     summary_file = out_dir / root_params.get_summary_csv_filename()
+    use_cache = root_params.software_config.use_cache
 
     msg = f"Starting Quality Assurance for input file: {input_file}"
     log.info(msg)
@@ -86,12 +87,12 @@ def verify_igram(
 
     try:
         if product_type == "rifg":
-            product = nisarqa.RIFG(input_file)
+            product = nisarqa.RIFG(input_file, use_cache=use_cache)
         elif product_type == "runw":
-            product = nisarqa.RUNW(input_file)
+            product = nisarqa.RUNW(input_file, use_cache=use_cache)
         else:
             assert product_type == "gunw"
-            product = nisarqa.GUNW(input_file)
+            product = nisarqa.GUNW(input_file, use_cache=use_cache)
     except:
         # Input product could not be opened via the product reader.
         summary.check_can_open_input_file(result="FAIL")

--- a/src/nisarqa/products/offsets.py
+++ b/src/nisarqa/products/offsets.py
@@ -61,6 +61,7 @@ def verify_offset(
     report_file = out_dir / root_params.get_report_pdf_filename()
     stats_file = out_dir / root_params.get_stats_h5_filename()
     summary_file = out_dir / root_params.get_summary_csv_filename()
+    use_cache = root_params.software_config.use_cache
 
     msg = f"Starting Quality Assurance for input file: {input_file}"
     log.info(msg)
@@ -70,13 +71,12 @@ def verify_offset(
     # Initialize the PASS/FAIL checks summary file
     nisarqa.setup_summary_csv(summary_file)
     summary = nisarqa.get_summary()
-
     try:
         if product_type == "roff":
-            product = nisarqa.ROFF(input_file)
+            product = nisarqa.ROFF(input_file, use_cache=use_cache)
         else:
             assert product_type == "goff"
-            product = nisarqa.GOFF(input_file)
+            product = nisarqa.GOFF(input_file, use_cache=use_cache)
     except:
         # Input product could not be opened via the product reader.
         summary.check_can_open_input_file(result="FAIL")

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 import os
+import tempfile
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import cached_property, lru_cache
 from pathlib import Path
-from typing import Any, overload
-from pathlib import Path
-import tempfile
+from typing import overload
 
 import h5py
 import isce3

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from functools import cached_property, lru_cache
 from pathlib import Path
 from typing import Any, overload
-from numpy.typing import ArrayLike
 from pathlib import Path
 import tempfile
 

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -403,7 +403,7 @@ def _get_or_create_cached_memmap(
     # of the QA scratch directory without thinking through all consequences,
     # this assertion will alert us to the issue.
     msg = (
-        "A file already exists with the memory-mapped file's default path" 
+        "A file already exists with the memory-mapped file's default path"
         f" and name: {mmap_file}"
     )
     assert not mmap_file.exists(), msg

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -434,7 +434,7 @@ def _get_or_create_cached_memmap(
             ----------
             arr_shape : pair of int
                 The shape of the 2-D input array to be iterated over.
-            block_size : pair of int
+            block_shape : pair of int
                 The shape of the tiles (rows, cols).
 
             Yields
@@ -455,9 +455,9 @@ def _get_or_create_cached_memmap(
                     yield slices
 
         with nisarqa.log_runtime(f"Create memmap for {img_path}"):
-
             for tile in iterate_by_tiles(
-                h5_ds, (axis0_tile_dim, axis1_tile_dim)
+                arr_shape=(h5_ds.shape[0], h5_ds.shape[1]),
+                block_shape=(axis0_tile_dim, axis1_tile_dim),
             ):
                 img_memmap[tile] = h5_ds[tile]
 

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -414,7 +414,7 @@ def _get_or_create_cached_memmap(
 
         # tuple giving the chunk shape, or None if chunked storage is not used
         if (chunks := h5_ds.chunks) is not None:
-            log.info(f"Dataset {dataset_path} has chunk shape {chunks}.")
+            log.debug(f"Dataset {dataset_path} has chunk shape {chunks}.")
             # Number of chunk dimensions must match number of Dataset dimensions.
             assert len(chunks) == 2
             # Edge case: dimension(s) are smaller than the chunk size,
@@ -427,7 +427,7 @@ def _get_or_create_cached_memmap(
             default_tile_height = 32
             tile_height = min(default_tile_height, shape[0])
             tile_width = shape[1]
-            log.info(
+            log.debug(
                 f"Dataset {dataset_path} not written with chunked storage."
                 f" Input array with shape {shape} will be copied tile-by-tile"
                 " to memory-mapped file using tile shape"

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -398,7 +398,7 @@ def _get_or_create_cached_memmap(
     log = nisarqa.get_logger()
 
     # Construct file name for memory-mapped file
-    cache_dir = nisarqa.scratch_directory(dir_=cache_dir, delete=False)
+    cache_dir = nisarqa.make_scratch_directory(dir_=cache_dir)
     mmap_file = cache_dir / f"{dataset_path.replace('/', '-')}.dat"
 
     # Create a memmap with dtype and shape that matches our data
@@ -1641,7 +1641,7 @@ class NisarRadarProduct(NisarProduct):
         if self.use_cache:
             kwargs["data"] = _get_or_create_cached_memmap(
                 input_file=self.filepath,
-                img_path=raster_path,
+                dataset_path=raster_path,
                 cache_dir=self.cache_dir,
             )
         else:
@@ -1924,7 +1924,7 @@ class NisarGeoProduct(NisarProduct):
         if self.use_cache:
             kwargs["data"] = _get_or_create_cached_memmap(
                 input_file=self.filepath,
-                img_path=raster_path,
+                dataset_path=raster_path,
                 cache_dir=self.cache_dir,
             )
         else:

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -342,12 +342,13 @@ def _get_dataset_handle(
 
 
 @lru_cache
-def _get_memmap(
+def _get_or_create_cached_memmap(
     input_file: str | os.PathLike,
     img_path: str,
     cache_dir: str | os.PathLike | None = None,
 ) -> np.memmap:
     """
+    Get or create a cached memmap of the requested Dataset.
 
     Parameters
     ----------
@@ -423,72 +424,42 @@ def _get_memmap(
                 f" with tile shape ({axis0_tile_dim}, {axis1_tile_dim})."
             )
 
+        def iterate_by_tiles(
+            *, arr_shape: tuple[int, int], block_shape: tuple[int, int]
+        ) -> Iterator[tuple[slice, slice]]:
+            """
+            Iterates over a NumPy array in blocks.
+
+            Parameters
+            ----------
+            arr_shape : pair of int
+                The shape of the 2-D input array to be iterated over.
+            block_size : pair of int
+                The shape of the tiles (rows, cols).
+
+            Yields
+            ------
+            slices : tuple of slices
+                Pair of slices which define a 2D sub-block of input array.
+                    Format: ( <axes 0 rows slice>, <axes 1 columns slice> )
+            """
+            rows, cols = arr_shape
+            block_rows, block_cols = block_shape
+
+            for i in range(0, rows, block_rows):
+                for j in range(0, cols, block_cols):
+                    slices = (
+                        slice(i, i + block_rows),
+                        slice(j, j + block_cols),
+                    )
+                    yield slices
+
         with nisarqa.log_runtime(f"Create memmap for {img_path}"):
-            # Note: TileIterator is constrained such that the 'uneven edges'
-            # are truncated. Will first memmap the full tiles, and then memmap
-            # the "leftover" right and bottom edges.
 
-            with nisarqa.log_runtime(f"memmap full tiles for {img_path}"):
-                # Step 1: memmap full tiles (edges are truncated)
-                tile_iter = nisarqa.TileIterator(
-                    arr_shape=arr_shape,
-                    axis_0_tile_dim=axis0_tile_dim,
-                    axis_1_tile_dim=axis1_tile_dim,
-                )
-                for tile in tile_iter:
-                    img_memmap[tile] = h5_ds[tile]
-
-            if arr_shape[0] % axis0_tile_dim > 0:
-                with nisarqa.log_runtime(f"memmap right side for {img_path}"):
-                    # Step 2: memmap the "leftover" right edge
-                    # Do not include leftover "bottom" edge here; do that below
-                    right_axis0_slice = slice(
-                        0,
-                        arr_shape[0] - (arr_shape[0] % axis0_tile_dim),
-                    )
-                    right_axis1_slice = slice(
-                        arr_shape[1] - (arr_shape[1] % axis1_tile_dim),
-                        arr_shape[1],
-                    )
-                    right_side = nisarqa.SubBlock2D(
-                        arr=h5_ds, slices=[right_axis0_slice, right_axis1_slice]
-                    )
-                    right_side_iter = nisarqa.TileIterator(
-                        arr_shape=right_side.shape,
-                        axis_0_tile_dim=axis0_tile_dim,
-                    )
-                    for tile in right_side_iter:
-                        img_memmap[tile] = right_side[tile]
-
-            if arr_shape[1] % axis1_tile_dim > 0:
-                with nisarqa.log_runtime(f"memmap bottom for {img_path}"):
-                    # Step 3: memmap the "leftover" bottom edge
-                    bottom_axis0_slice = slice(
-                        arr_shape[0] - (arr_shape[0] % axis0_tile_dim),
-                        arr_shape[0],
-                    )
-                    bottom_axis1_slice = slice(
-                        0,
-                        arr_shape[1] - (arr_shape[1] % axis1_tile_dim),
-                    )
-
-                    bottom_side = nisarqa.SubBlock2D(
-                        arr=h5_ds,
-                        slices=[bottom_axis0_slice, bottom_axis1_slice],
-                    )
-                    bottom_side_iter = nisarqa.TileIterator(
-                        arr_shape=bottom_side.shape,
-                        axis_1_tile_dim=axis1_tile_dim,
-                    )
-                    for tile in bottom_side_iter:
-                        img_memmap[tile] = bottom_side[tile]
-
-            if (arr_shape[0] % axis0_tile_dim > 0) and (
-                arr_shape[1] % axis1_tile_dim > 0
+            for tile in iterate_by_tiles(
+                h5_ds, (axis0_tile_dim, axis1_tile_dim)
             ):
-                # Step 4: memmap the bottom-right corner
-                corner_slices = (bottom_axis0_slice, right_axis1_slice)
-                img_memmap[corner_slices] = h5_ds[corner_slices]
+                img_memmap[tile] = h5_ds[tile]
 
         return img_memmap
 
@@ -1684,7 +1655,7 @@ class NisarRadarProduct(NisarProduct):
         dataset = _get_dataset_handle(h5_file, raster_path)
 
         if self.use_cache:
-            kwargs["data"] = _get_memmap(
+            kwargs["data"] = _get_or_create_cached_memmap(
                 input_file=self.filepath,
                 img_path=raster_path,
                 cache_dir=self.cache_dir,
@@ -1967,7 +1938,7 @@ class NisarGeoProduct(NisarProduct):
         dataset = _get_dataset_handle(h5_file, raster_path)
 
         if self.use_cache:
-            kwargs["data"] = _get_memmap(
+            kwargs["data"] = _get_or_create_cached_memmap(
                 input_file=self.filepath,
                 img_path=raster_path,
                 cache_dir=self.cache_dir,

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -5,11 +5,12 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
-from functools import cache, cached_property, lru_cache
+from functools import cached_property, lru_cache
 from pathlib import Path
-import random
 from typing import Any, overload
 from numpy.typing import ArrayLike
+from pathlib import Path
+import tempfile
 
 import h5py
 import isce3
@@ -342,41 +343,153 @@ def _get_dataset_handle(
 
 @lru_cache
 def _get_memmap(
-    input_file: str, img_path: str, scratch_dir: str
-) -> tuple[str, str, Any]:
-    """TODO"""
+    input_file: str | os.PathLike,
+    img_path: str,
+    cache_dir: str | os.PathLike | None = None,
+) -> np.memmap:
+    """
+
+    Parameters
+    ----------
+    input_file : path-like
+        HDF5 input file.
+    img_path : string
+        Path in the HDF5 input file to the 2-D Dataset to be memmap'ed.
+        Example: "/science/LSAR/RSLC/swaths/frequencyA/HH".
+    cache_dir : path-like or None, optional
+        Directory where QA software may write memmap data.
+        If `cache_dir` is a path-like object, a directory will be created at the
+        specified file system path if it did not already exist.
+        If `cache_dir` is None, a temporary directory will be created as though by
+        `tempfile.mkdtemp()`.
+        Directory and memmap files will not be cleaned up by this function.
+        Defaults to None.
+
+    Returns
+    -------
+    img_memmap : numpy.memmap
+        `memmap` copy of the `img_path` Dataset.
+
+    Notes
+    -----
+    Prior to Python 3.13 there is no API to close the underlying mmap.
+    So, the memmap will remain open for the duration of the program.
+    Source: https://numpy.org/doc/2.2/reference/generated/numpy.memmap.html
+    """
+    log = nisarqa.get_logger()
+
     # Get tmp memmap file name
-    img_name = img_path.split("SAR/")[-1].replace("/", "-")
+    with nisarqa.scratch_directory(dir_=cache_dir, delete=False):
+        tmp_file = Path(cache_dir) / f"{img_path.replace('/', '-')}.dat"
 
-    random_number = random.randint(1, 100000)
-    tmp_file = Path(scratch_dir, f"memmap-{img_name}-{random_number}.dat")
-
-    # Create a memmap with dtype and shape that matches our data:
+    # Create a memmap with dtype and shape that matches our data
     with h5py.File(input_file, "r") as h5_f:
         h5_ds = _get_dataset_handle(h5_file=h5_f, raster_path=img_path)
+        arr_shape = np.shape(h5_ds)
+        if len(arr_shape) != 2:
+            raise ValueError(
+                f"Input array has {len(arr_shape)} dimensions, but must be 2D."
+            )
 
         img_memmap = np.memmap(
-            tmp_file, dtype="complex64", mode="w+", shape=h5_ds.shape
+            tmp_file, dtype=h5_ds.dtype, mode="w+", shape=arr_shape
         )
 
         # Write data to memmap.
         # Note: This is an expensive operation. All decompression,
         # de-chunking, etc. costs are incurred here.
-        with nisarqa.log_runtime(f"Create memmap for {img_path}"):
-            tile_iter = nisarqa.TileIterator(
-                arr_shape=h5_ds.shape,
-                axis_0_tile_dim=512,
-                axis_1_tile_dim=512,
+
+        # tuple giving the chunk shape, or None if chunked storage is not used
+        chunks = h5_ds.chunks
+        if chunks is not None:
+            axis0_tile_dim = chunks[0]
+            axis1_tile_dim = chunks[1]
+            log.info(f"Dataset {img_path} has chunk shape {chunks}.")
+
+            # Edge case: dimension(s) are smaller than the chunk size,
+            # so adjust the lengths which will be used for the tile iterators
+            if arr_shape[0] < axis0_tile_dim:
+                axis0_tile_dim = arr_shape[0]
+            if arr_shape[1] < axis1_tile_dim:
+                axis1_tile_dim = arr_shape[1]
+
+        else:
+            # HDF5 defaults to row-major ordering, so use full rows
+            axis0_tile_dim = min(32, arr_shape[0])  # not too big
+            axis1_tile_dim = arr_shape[1]
+            log.info(
+                f"Dataset {img_path} not written with chunked storage."
+                f" Input array with shape {arr_shape} will be memmap'ed"
+                f" with tile shape ({axis0_tile_dim}, {axis1_tile_dim})."
             )
 
-            # Ok to pass the full input array; the tiling iterators
-            # are constrained such that the 'uneven edges' will be ignored.
-            for tile in tile_iter:
-                img_memmap[tile] = h5_ds[tile]
+        with nisarqa.log_runtime(f"Create memmap for {img_path}"):
+            # Note: TileIterator is constrained such that the 'uneven edges'
+            # are truncated. Will first memmap the full tiles, and then memmap
+            # the "leftover" right and bottom edges.
 
-        # Prior to Python 3.13 there is no API to close the underlying mmap.
-        # So, the memmap will remain open for the duration of the program.
-        # Source: https://numpy.org/doc/2.2/reference/generated/numpy.memmap.html
+            with nisarqa.log_runtime(f"memmap full tiles for {img_path}"):
+                # Step 1: memmap full tiles (edges are truncated)
+                tile_iter = nisarqa.TileIterator(
+                    arr_shape=arr_shape,
+                    axis_0_tile_dim=axis0_tile_dim,
+                    axis_1_tile_dim=axis1_tile_dim,
+                )
+                for tile in tile_iter:
+                    img_memmap[tile] = h5_ds[tile]
+
+            if arr_shape[0] % axis0_tile_dim > 0:
+                with nisarqa.log_runtime(f"memmap right side for {img_path}"):
+                    # Step 2: memmap the "leftover" right edge
+                    # Do not include leftover "bottom" edge here; do that below
+                    right_axis0_slice = slice(
+                        0,
+                        arr_shape[0] - (arr_shape[0] % axis0_tile_dim),
+                    )
+                    right_axis1_slice = slice(
+                        arr_shape[1] - (arr_shape[1] % axis1_tile_dim),
+                        arr_shape[1],
+                    )
+                    right_side = nisarqa.SubBlock2D(
+                        arr=h5_ds, slices=[right_axis0_slice, right_axis1_slice]
+                    )
+                    right_side_iter = nisarqa.TileIterator(
+                        arr_shape=right_side.shape,
+                        axis_0_tile_dim=axis0_tile_dim,
+                    )
+                    for tile in right_side_iter:
+                        img_memmap[tile] = right_side[tile]
+
+            if arr_shape[1] % axis1_tile_dim > 0:
+                with nisarqa.log_runtime(f"memmap bottom for {img_path}"):
+                    # Step 3: memmap the "leftover" bottom edge
+                    bottom_axis0_slice = slice(
+                        arr_shape[0] - (arr_shape[0] % axis0_tile_dim),
+                        arr_shape[0],
+                    )
+                    bottom_axis1_slice = slice(
+                        0,
+                        arr_shape[1] - (arr_shape[1] % axis1_tile_dim),
+                    )
+
+                    bottom_side = nisarqa.SubBlock2D(
+                        arr=h5_ds,
+                        slices=[bottom_axis0_slice, bottom_axis1_slice],
+                    )
+                    bottom_side_iter = nisarqa.TileIterator(
+                        arr_shape=bottom_side.shape,
+                        axis_1_tile_dim=axis1_tile_dim,
+                    )
+                    for tile in bottom_side_iter:
+                        img_memmap[tile] = bottom_side[tile]
+
+            if (arr_shape[0] % axis0_tile_dim > 0) and (
+                arr_shape[1] % axis1_tile_dim > 0
+            ):
+                # Step 4: memmap the bottom-right corner
+                corner_slices = (bottom_axis0_slice, right_axis1_slice)
+                img_memmap[corner_slices] = h5_ds[corner_slices]
+
         return img_memmap
 
 
@@ -389,10 +502,26 @@ class NisarProduct(ABC):
     ----------
     filepath : path-like
         Filepath to the input product.
+    use_cache : bool, optional
+        True to use memory map(s) to cache select Dataset(s).
+        False to always read data directly from the input file.
+        Generally, enabling caching should reduce runtime.
+        Defaults to False.
+    cache_dir : path-like, optional
+        Existing directory where QA software may write temporary data.
+        Temporary files are not guaranteed to be deleted upon exiting.
+        If `cache_dir` is a path-like object, it should already exist.
+        If `use_cache` is True and if `cache_dir` is None, a temporary
+        directory will be created as though by `tempfile.mkdtemp()`
+        and `cache_dir` instance attribute will be updated.
+        If `cache_dir` is None and if `use_cache` is False, a temporary
+        directory will not be created.
+        Defaults to None.
     """
 
-    # Full file path to the input product file.
     filepath: str
+    use_cache: bool = False
+    cache_dir: str | os.PathLike | None = None
 
     def __post_init__(self):
         # Verify that the input product contained a product spec version.
@@ -402,6 +531,17 @@ class NisarProduct(ABC):
         self._check_root_path()
         self._check_is_geocoded()
         self._check_data_group_path()
+
+        if self.cache_dir is None:
+            if self.use_cache:
+                object.__setattr__(self, "cache_dir", Path(tempfile.mkdtemp()))
+        else:
+            # cache directory should already exist
+            path = Path(self.cache_dir)
+            if not (path.exists() and path.is_dir()):
+                raise ValueError(
+                    f"{self.cache_dir=}; does not exist or is not a directory."
+                )
 
     @property
     @abstractmethod
@@ -1173,11 +1313,6 @@ class NisarProduct(ABC):
 
         return path
 
-    def _image_cache(self, img_path: str) -> ArrayLike:
-        """TODO: Docstring"""
-
-        return _get_memmap(self.filepath, img_path, scratch_dir)
-
     @abstractmethod
     def _get_raster_from_path(
         self, h5_file: h5py.File, raster_path: str, *, parse_stats: bool
@@ -1548,9 +1683,12 @@ class NisarRadarProduct(NisarProduct):
         # Get dataset object and check for correct dtype
         dataset = _get_dataset_handle(h5_file, raster_path)
 
-        use_cache = True
-        if use_cache:
-            kwargs["data"] = self._image_cache(img_path=raster_path)
+        if self.use_cache:
+            kwargs["data"] = _get_memmap(
+                input_file=self.filepath,
+                img_path=raster_path,
+                cache_dir=self.cache_dir,
+            )
         else:
             kwargs["data"] = dataset
 
@@ -1827,7 +1965,15 @@ class NisarGeoProduct(NisarProduct):
 
         # Get dataset object and check for correct dtype
         dataset = _get_dataset_handle(h5_file, raster_path)
-        kwargs["data"] = dataset
+
+        if self.use_cache:
+            kwargs["data"] = _get_memmap(
+                input_file=self.filepath,
+                img_path=raster_path,
+                cache_dir=self.cache_dir,
+            )
+        else:
+            kwargs["data"] = dataset
 
         kwargs["units"] = _get_units(dataset)
         kwargs["fill_value"] = _get_fill_value(dataset)

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -343,16 +343,15 @@ def _get_dataset_handle(
 def _get_or_create_cached_memmap(
     input_file: str | os.PathLike,
     dataset_path: str,
-    cache_dir: str | os.PathLike | None = None,
     default_tile_height: int = 32,
 ) -> np.memmap:
     """
     Get or create a cached memmap of the requested Dataset.
 
-    On first invocation, creates a memory-mapped file in the cache directory
-    and copies the contents of a 2D HDF5 Dataset to that file. The memory map
-    object is cached and simply returned on subsequent invocations with the
-    same arguments.
+    On first invocation, creates a memory-mapped file in the global
+    scratch directory and copies the contents of a 2D HDF5 Dataset to that file.
+    The memory map object is cached and simply returned on subsequent
+    invocations with the same arguments.
 
     The Dataset contents are copied tile-by-tile to avoid oversubscribing
     system memory. If the Dataset is chunked, the tile shape will match the
@@ -368,15 +367,6 @@ def _get_or_create_cached_memmap(
         Path in the HDF5 input file to the 2D Dataset to be copied to a
         memory-mapped file.
         Example: "/science/LSAR/RSLC/swaths/frequencyA/HH".
-    cache_dir : path-like or None, optional
-        Directory where QA software may write memory-mapped files.
-        If `cache_dir` is a path-like object, a directory will be created at the
-        specified file system path if it did not already exist.
-        If `cache_dir` is None, a temporary directory will be created as
-        though by `tempfile.mkdtemp()`.
-        The user is responsible for deleting the cache directory and its
-        contents when done with it.
-        Defaults to None.
     default_tile_height : int, optional
         If Dataset is not chunked, then the tile shape used to copy the data
         defaults to: (<default_tile_height>, <dataset axis 1 width>).
@@ -386,6 +376,16 @@ def _get_or_create_cached_memmap(
     -------
     img_memmap : numpy.memmap
         `memmap` copy of the `dataset_path` Dataset.
+
+    Raises
+    ------
+    ValueError :
+        If a file already exists on the disk with the exact filepath as
+        determined within this function. This might occur if the
+        function is called subsequently with the same `input_file`
+        and `dataset_path` arguments, but a different `default_tile_height`
+        argument; if so, then please call this function with the same
+        `default_tile_height` as before.
     """
     # Note: numpy.memmap relies on mmap.mmap, which, prior to Python 3.13,
     # had no interface to close the underlying file descriptor.
@@ -398,8 +398,19 @@ def _get_or_create_cached_memmap(
     log = nisarqa.get_logger()
 
     # Construct file name for memory-mapped file
-    cache_dir = nisarqa.make_scratch_directory(dir_=cache_dir)
-    mmap_file = cache_dir / f"{dataset_path.replace('/', '-')}.dat"
+    mmap_file = (
+        nisarqa.get_global_scratch() / f"{dataset_path.replace('/', '-')}.dat"
+    )
+
+    if mmap_file.exists():
+        raise ValueError(
+            "Cached memory-mapped file already created for input file"
+            f" {input_file} and Dataset {dataset_path}, located in the"
+            f" global scratch directory at: {mmap_file}."
+            " Suggest using the same `default_tile_height` argument"
+            " as when `_get_or_create_cached_memmap()` was first called for"
+            " this input file and Dataset pair."
+        )
 
     # Create a memmap with dtype and shape that matches our data
     with h5py.File(input_file, "r") as h5_f:
@@ -461,26 +472,15 @@ class NisarProduct(ABC):
     filepath : path-like
         Filepath to the input product.
     use_cache : bool, optional
-        True to use memory map(s) to cache select Dataset(s).
+        True to use memory map(s) to cache select Dataset(s) in
+        memory-mapped files in the global scratch directory.
         False to always read data directly from the input file.
         Generally, enabling caching should reduce runtime.
         Defaults to False.
-    cache_dir : path-like or None, optional
-        Directory where QA software may write temporary data.
-        If `cache_dir` is a path-like object, the directory will created if
-        it does not already exist.
-        If `cache_dir` is None, a temporary directory will be created as though
-        by `tempfile.mkdtemp()`, and the `cache_dir` attribute will be updated.
-        If `use_cache` is False, this parameter is ignored (no directory
-        will be created).
-        The user is responsible for deleting the cache directory and its
-        contents when done with it.
-        Defaults to None.
     """
 
     filepath: str
     use_cache: bool = False
-    cache_dir: str | os.PathLike | None = None
 
     def __post_init__(self):
         # Verify that the input product contained a product spec version.
@@ -490,13 +490,6 @@ class NisarProduct(ABC):
         self._check_root_path()
         self._check_is_geocoded()
         self._check_data_group_path()
-
-        if self.use_cache:
-            if self.cache_dir is None:
-                self.cache_dir = Path(tempfile.mkdtemp())
-            else:
-                path = Path(self.cache_dir)
-                path.mkdir(parents=True, exist_ok=True)
 
     @property
     @abstractmethod
@@ -1642,7 +1635,6 @@ class NisarRadarProduct(NisarProduct):
             kwargs["data"] = _get_or_create_cached_memmap(
                 input_file=self.filepath,
                 dataset_path=raster_path,
-                cache_dir=self.cache_dir,
             )
         else:
             kwargs["data"] = dataset
@@ -1925,7 +1917,6 @@ class NisarGeoProduct(NisarProduct):
             kwargs["data"] = _get_or_create_cached_memmap(
                 input_file=self.filepath,
                 dataset_path=raster_path,
-                cache_dir=self.cache_dir,
             )
         else:
             kwargs["data"] = dataset

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -341,7 +341,7 @@ def _get_dataset_handle(
         return dataset
 
 
-@lru_cache
+@nisarqa.lru_cache_with_frozen_argument("default_tile_height")
 def _get_or_create_cached_memmap(
     input_file: str | os.PathLike,
     dataset_path: str,
@@ -373,6 +373,11 @@ def _get_or_create_cached_memmap(
         If Dataset is not chunked, then the tile shape used to copy the data
         defaults to: (<default_tile_height>, <dataset.shape[1]>).
         Ignored if Dataset is chunked. Defaults to 32.
+        Warning: This parameter's argument value is "frozen" upon first
+        invocation of `_get_or_create_cached_memmap()`, regardless of the
+        changes to the other parameters. Please ensure that the argument
+        provided the first time this function is called will be appropriate
+        for all subsequent non-chuncked Datasets that will be cached.
 
     Returns
     -------
@@ -468,10 +473,17 @@ class NisarProduct(ABC):
         False to always read data directly from the input file.
         Generally, enabling caching should reduce runtime.
         Defaults to False.
+    default_tile_height : int, optional
+        If `use_cache` is True and if a Dataset is not chunked, then when a
+        Dataset is copied to a memory-mapped file, the tile shape used to copy
+        the data defaults to: (<default_tile_height>, <dataset.shape[1]>).
+        Ignored if a Dataset is chunked. Ignored if `use_cache` is False.
+        Defaults to 32.
     """
 
     filepath: str
     use_cache: bool = False
+    default_tile_height: int = 32
 
     def __post_init__(self):
         # Verify that the input product contained a product spec version.
@@ -1626,6 +1638,7 @@ class NisarRadarProduct(NisarProduct):
             kwargs["data"] = _get_or_create_cached_memmap(
                 input_file=self.filepath,
                 dataset_path=raster_path,
+                default_tile_height=self.default_tile_height,
             )
         else:
             kwargs["data"] = dataset
@@ -1908,6 +1921,7 @@ class NisarGeoProduct(NisarProduct):
             kwargs["data"] = _get_or_create_cached_memmap(
                 input_file=self.filepath,
                 dataset_path=raster_path,
+                default_tile_height=self.default_tile_height,
             )
         else:
             kwargs["data"] = dataset

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -383,7 +383,7 @@ def _get_or_create_cached_memmap(
 
     # Construct file name for memory-mapped file
     filename = f"{dataset_path.replace('/', '-')}.dat"
-    mmap_file = nisarqa.get_global_scratch() / filename
+    mmap_file = nisarqa.get_global_scratch_dir() / filename
 
     # A user should never be able to trip this assert because the scratch
     # directory should always be unique. But if we change the behavior

--- a/src/nisarqa/products/rslc.py
+++ b/src/nisarqa/products/rslc.py
@@ -21,6 +21,7 @@ import nisarqa
 objects_to_skip = nisarqa.get_all(name=__name__)
 
 
+@nisarqa.prep_scratch_dir_from_root_params
 def verify_rslc(
     root_params: nisarqa.RSLCRootParamGroup, verbose: bool = False
 ) -> None:
@@ -59,6 +60,7 @@ def verify_rslc(
     report_file = out_dir / root_params.get_report_pdf_filename()
     stats_file = out_dir / root_params.get_stats_h5_filename()
     summary_file = out_dir / root_params.get_summary_csv_filename()
+    scratch_dir = root_params.prodpath.scratch_dir
 
     msg = f"Starting Quality Assurance for input file: {input_file}"
     log.info(msg)
@@ -71,7 +73,12 @@ def verify_rslc(
 
     try:
         # All worksflows use the RSLC() product; only initialize once.
-        product = nisarqa.RSLC(filepath=input_file)
+        product = nisarqa.RSLC(
+            filepath=input_file,
+            use_cache=root_params.software_config.use_cache,
+            cache_dir=scratch_dir,
+            # prime_the_cache=True,  # we analyze all images, so prime the cache
+        )
     except:
         # Input product could not be opened via the product reader.
         summary.check_can_open_input_file(result="FAIL")

--- a/src/nisarqa/products/rslc.py
+++ b/src/nisarqa/products/rslc.py
@@ -262,6 +262,7 @@ def verify_rslc(
                 dyn_anc_params=root_params.anc_files,
                 rslc=product,
                 stats_filename=stats_file,
+                scratch_dir=scratch_dir,
             )
             log.info(
                 "Absolute Radiometric Calibration CalTool results saved to"
@@ -297,6 +298,7 @@ def verify_rslc(
                 dyn_anc_params=root_params.anc_files,
                 rslc=product,
                 stats_filename=stats_file,
+                scratch_dir=scratch_dir,
             )
             log.info(
                 f"Point Target Analyzer CalTool results saved to {stats_file}."

--- a/src/nisarqa/products/rslc.py
+++ b/src/nisarqa/products/rslc.py
@@ -455,7 +455,6 @@ def process_backscatter_imgs_and_browse(
 
 
 # TODO - move to generic location
-@nisarqa.log_function_start_and_stop_time
 def get_multilooked_backscatter_img(
     img, params, stats_h5, input_raster_represents_power=False
 ):
@@ -1188,7 +1187,6 @@ def process_backscatter_and_phase_histograms(
             )
 
 
-@nisarqa.log_function_start_and_stop_time
 def generate_backscatter_image_histogram_single_freq(
     product: nisarqa.NonInsarProduct,
     freq: str,
@@ -1338,7 +1336,6 @@ def generate_backscatter_image_histogram_single_freq(
     log.info(f"Backscatter Image Histograms for Frequency {freq} complete.")
 
 
-@nisarqa.log_function_start_and_stop_time
 def generate_phase_histogram_single_freq(
     product: nisarqa.NonInsarProduct,
     freq: str,
@@ -1556,7 +1553,6 @@ def process_range_spectra(
             )
 
 
-@nisarqa.log_function_start_and_stop_time
 def generate_range_spectra_single_freq(
     product: nisarqa.RSLC,
     freq: str,
@@ -1745,7 +1741,6 @@ def process_azimuth_spectra(
             )
 
 
-@nisarqa.log_function_start_and_stop_time
 def generate_az_spectra_single_freq(
     product: nisarqa.RSLC,
     freq: str,

--- a/src/nisarqa/products/rslc.py
+++ b/src/nisarqa/products/rslc.py
@@ -389,7 +389,7 @@ def process_backscatter_imgs_and_browse(
         for pol in product.get_pols(freq=freq):
             # Open the *SARRaster image
 
-            with product.get_raster(freq=freq, pol=pol) as img:
+            with product.get_raster(freq="B", pol=pol) as img:
                 with nisarqa.log_runtime(
                     f"`get_multilooked_backscatter_img` for Frequency {freq}"
                     f" Polarization {pol}"

--- a/src/nisarqa/products/rslc.py
+++ b/src/nisarqa/products/rslc.py
@@ -361,8 +361,6 @@ def process_backscatter_imgs_and_browse(
         "GCOV Backscatter Coefficient (gamma-0)".
         Defaults to "Backscatter Coefficient".
     """
-    log = nisarqa.get_logger()
-    log.info("Beginning processing of backscatter images...")
 
     # Select which layers will be needed for the browse image.
     # Multilooking takes a long time, but each multilooked polarization image
@@ -455,10 +453,9 @@ def process_backscatter_imgs_and_browse(
     # Construct the browse image
     product.save_browse(pol_imgs=pol_imgs_for_browse, filepath=browse_filename)
 
-    log.info("Processing complete for backscatter images.")
-
 
 # TODO - move to generic location
+@nisarqa.log_function_start_and_stop_time
 def get_multilooked_backscatter_img(
     img, params, stats_h5, input_raster_represents_power=False
 ):
@@ -1163,8 +1160,6 @@ def process_backscatter_and_phase_histograms(
     """
 
     # Generate and store the histograms
-    log = nisarqa.get_logger()
-    log.info("Beginning processing of backscatter and phase histograms...")
 
     for freq in product.freqs:
         with nisarqa.log_runtime(
@@ -1193,6 +1188,7 @@ def process_backscatter_and_phase_histograms(
             )
 
 
+@nisarqa.log_function_start_and_stop_time
 def generate_backscatter_image_histogram_single_freq(
     product: nisarqa.NonInsarProduct,
     freq: str,
@@ -1342,6 +1338,7 @@ def generate_backscatter_image_histogram_single_freq(
     log.info(f"Backscatter Image Histograms for Frequency {freq} complete.")
 
 
+@nisarqa.log_function_start_and_stop_time
 def generate_phase_histogram_single_freq(
     product: nisarqa.NonInsarProduct,
     freq: str,
@@ -1480,7 +1477,6 @@ def generate_phase_histogram_single_freq(
 
         # Close figure
         plt.close(fig)
-
     else:
         # Remove unused dataset from STATS.h5 because no phase histogram was
         # generated.
@@ -1560,6 +1556,7 @@ def process_range_spectra(
             )
 
 
+@nisarqa.log_function_start_and_stop_time
 def generate_range_spectra_single_freq(
     product: nisarqa.RSLC,
     freq: str,
@@ -1748,6 +1745,7 @@ def process_azimuth_spectra(
             )
 
 
+@nisarqa.log_function_start_and_stop_time
 def generate_az_spectra_single_freq(
     product: nisarqa.RSLC,
     freq: str,

--- a/src/nisarqa/products/rslc.py
+++ b/src/nisarqa/products/rslc.py
@@ -361,6 +361,8 @@ def process_backscatter_imgs_and_browse(
         "GCOV Backscatter Coefficient (gamma-0)".
         Defaults to "Backscatter Coefficient".
     """
+    log = nisarqa.get_logger()
+    log.info("Beginning processing of backscatter images...")
 
     # Select which layers will be needed for the browse image.
     # Multilooking takes a long time, but each multilooked polarization image
@@ -452,6 +454,8 @@ def process_backscatter_imgs_and_browse(
 
     # Construct the browse image
     product.save_browse(pol_imgs=pol_imgs_for_browse, filepath=browse_filename)
+
+    log.info("Processing complete for backscatter images.")
 
 
 # TODO - move to generic location
@@ -1159,6 +1163,8 @@ def process_backscatter_and_phase_histograms(
     """
 
     # Generate and store the histograms
+    log = nisarqa.get_logger()
+    log.info("Beginning processing of backscatter and phase histograms...")
 
     for freq in product.freqs:
         with nisarqa.log_runtime(
@@ -1474,6 +1480,7 @@ def generate_phase_histogram_single_freq(
 
         # Close figure
         plt.close(fig)
+
     else:
         # Remove unused dataset from STATS.h5 because no phase histogram was
         # generated.

--- a/src/nisarqa/products/rslc.py
+++ b/src/nisarqa/products/rslc.py
@@ -21,7 +21,6 @@ import nisarqa
 objects_to_skip = nisarqa.get_all(name=__name__)
 
 
-@nisarqa.prep_scratch_dir_from_root_params
 def verify_rslc(
     root_params: nisarqa.RSLCRootParamGroup, verbose: bool = False
 ) -> None:
@@ -60,7 +59,6 @@ def verify_rslc(
     report_file = out_dir / root_params.get_report_pdf_filename()
     stats_file = out_dir / root_params.get_stats_h5_filename()
     summary_file = out_dir / root_params.get_summary_csv_filename()
-    scratch_dir = root_params.prodpath.scratch_dir
 
     msg = f"Starting Quality Assurance for input file: {input_file}"
     log.info(msg)
@@ -76,7 +74,6 @@ def verify_rslc(
         product = nisarqa.RSLC(
             filepath=input_file,
             use_cache=root_params.software_config.use_cache,
-            cache_dir=scratch_dir,
             # prime_the_cache=True,  # we analyze all images, so prime the cache
         )
     except:
@@ -262,7 +259,6 @@ def verify_rslc(
                 dyn_anc_params=root_params.anc_files,
                 rslc=product,
                 stats_filename=stats_file,
-                scratch_dir=scratch_dir,
             )
             log.info(
                 "Absolute Radiometric Calibration CalTool results saved to"
@@ -298,7 +294,6 @@ def verify_rslc(
                 dyn_anc_params=root_params.anc_files,
                 rslc=product,
                 stats_filename=stats_file,
-                scratch_dir=scratch_dir,
             )
             log.info(
                 f"Point Target Analyzer CalTool results saved to {stats_file}."
@@ -389,7 +384,7 @@ def process_backscatter_imgs_and_browse(
         for pol in product.get_pols(freq=freq):
             # Open the *SARRaster image
 
-            with product.get_raster(freq="B", pol=pol) as img:
+            with product.get_raster(freq=freq, pol=pol) as img:
                 with nisarqa.log_runtime(
                     f"`get_multilooked_backscatter_img` for Frequency {freq}"
                     f" Polarization {pol}"

--- a/src/nisarqa/utils/calc.py
+++ b/src/nisarqa/utils/calc.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections import namedtuple
 from collections.abc import Sequence
 
 import h5py

--- a/src/nisarqa/utils/input_verification.py
+++ b/src/nisarqa/utils/input_verification.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import os
 import re
-from datetime import datetime
 from typing import Any
 
 import h5py
 import numpy as np
-from numpy.typing import ArrayLike
 
 import nisarqa
 

--- a/src/nisarqa/utils/metadata_checks.py
+++ b/src/nisarqa/utils/metadata_checks.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import traceback
 from dataclasses import dataclass
 from itertools import chain
-from typing import TypeVar
 
 import h5py
 import numpy as np

--- a/src/nisarqa/utils/metadata_checks.py
+++ b/src/nisarqa/utils/metadata_checks.py
@@ -142,7 +142,7 @@ class MetadataLUT3D(MetadataLUT2D):
 
         len_z = len(self.z_coord_vector)
         if self.shape[-3] != len_z:
-            if self.name.endswith("Baseline"):
+            if self.name.endswith("Baseline") or self.name.endswith("TidesPhase"):
                 # `parallelBaseline` and `perpendicularBaseline` LUTs
                 # either have a height of 2 or the length of the z coordinates
                 if self.shape[-3] != 2:

--- a/src/nisarqa/utils/metadata_checks.py
+++ b/src/nisarqa/utils/metadata_checks.py
@@ -142,7 +142,9 @@ class MetadataLUT3D(MetadataLUT2D):
 
         len_z = len(self.z_coord_vector)
         if self.shape[-3] != len_z:
-            if self.name.endswith("Baseline") or self.name.endswith("TidesPhase"):
+            if self.name.endswith("Baseline") or self.name.endswith(
+                "TidesPhase"
+            ):
                 # `parallelBaseline` and `perpendicularBaseline` LUTs
                 # either have a height of 2 or the length of the z coordinates
                 if self.shape[-3] != 2:

--- a/src/nisarqa/utils/metadata_checks.py
+++ b/src/nisarqa/utils/metadata_checks.py
@@ -142,9 +142,7 @@ class MetadataLUT3D(MetadataLUT2D):
 
         len_z = len(self.z_coord_vector)
         if self.shape[-3] != len_z:
-            if self.name.endswith("Baseline") or self.name.endswith(
-                "TidesPhase"
-            ):
+            if self.name.endswith("Baseline"):
                 # `parallelBaseline` and `perpendicularBaseline` LUTs
                 # either have a height of 2 or the length of the z coordinates
                 if self.shape[-3] != 2:

--- a/src/nisarqa/utils/metadata_checks.py
+++ b/src/nisarqa/utils/metadata_checks.py
@@ -9,6 +9,7 @@ import numpy as np
 from osgeo import gdal, osr
 
 import nisarqa
+from nisarqa.utils.typing import MetadataLUTT
 
 objects_to_skip = nisarqa.get_all(name=__name__)
 
@@ -440,7 +441,7 @@ def is_gdal_friendly(input_filepath: str, ds_path: str) -> bool:
         return False
 
 
-def _lut_has_finite_pixels(ds: nisarqa.typing.MetadataLUTT) -> bool:
+def _lut_has_finite_pixels(ds: MetadataLUTT) -> bool:
     """
     Return False if LUT contains all non-finite values; True otherwise.
 
@@ -480,7 +481,7 @@ def _lut_has_finite_pixels(ds: nisarqa.typing.MetadataLUTT) -> bool:
     return True
 
 
-def _lut_is_not_all_zeros(ds: nisarqa.typing.MetadataLUTT) -> bool:
+def _lut_is_not_all_zeros(ds: MetadataLUTT) -> bool:
     """
     Return False if metadata LUT contains all near-zeros; True otherwise.
 

--- a/src/nisarqa/utils/raster_classes.py
+++ b/src/nisarqa/utils/raster_classes.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass, fields
 from functools import cached_property
-from typing import Any, Optional, overload, Sequence
+from typing import Any, Optional, Sequence, overload
 
 import h5py
 import numpy as np

--- a/src/nisarqa/utils/raster_classes.py
+++ b/src/nisarqa/utils/raster_classes.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import numbers
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass, fields
 from functools import cached_property
-from typing import Any, Optional, overload
+from typing import Any, Optional, overload, Sequence
 
 import h5py
 import numpy as np
@@ -139,6 +138,10 @@ class ComplexFloat16Decoder(object):
         original = self.dataset.__repr__()
         new = original.replace("HDF5 dataset", "ComplexFloat16Decoder")
         return new
+
+    @property
+    def chunks(self) -> Sequence[int]:
+        return self.dataset.chunks
 
 
 @dataclass

--- a/src/nisarqa/utils/raster_classes.py
+++ b/src/nisarqa/utils/raster_classes.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass, fields
 from functools import cached_property
+import re
 from typing import Any, Optional, overload
 
 import h5py

--- a/src/nisarqa/utils/raster_classes.py
+++ b/src/nisarqa/utils/raster_classes.py
@@ -5,7 +5,6 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass, fields
 from functools import cached_property
-import re
 from typing import Any, Optional, overload
 
 import h5py

--- a/src/nisarqa/utils/sanity_checks.py
+++ b/src/nisarqa/utils/sanity_checks.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Container
-from typing import Any, TypeVar
 
 import h5py
 import numpy as np
-from numpy.typing import ArrayLike
 
 import nisarqa
 

--- a/src/nisarqa/utils/sanity_checks.py
+++ b/src/nisarqa/utils/sanity_checks.py
@@ -6,6 +6,7 @@ import h5py
 import numpy as np
 
 import nisarqa
+from nisarqa.utils.typing import T
 
 objects_to_skip = nisarqa.get_all(name=__name__)
 
@@ -85,8 +86,8 @@ def identification_sanity_checks(
         return True
 
     def _verify_data_is_in_list(
-        value: nisarqa.typing.T | None,
-        valid_options: Container[nisarqa.typing.T],
+        value: T | None,
+        valid_options: Container[T],
         ds_name: str,
     ) -> bool:
         if (value is None) or (value not in valid_options):

--- a/src/nisarqa/utils/stats_h5_writer/metrics_writer.py
+++ b/src/nisarqa/utils/stats_h5_writer/metrics_writer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import h5py
-import numpy as np
 
 import nisarqa
 

--- a/src/nisarqa/utils/summary_csv.py
+++ b/src/nisarqa/utils/summary_csv.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import InitVar, dataclass
+from dataclasses import dataclass
 
 import nisarqa
 

--- a/src/nisarqa/utils/tiling.py
+++ b/src/nisarqa/utils/tiling.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from typing import Optional
 
 import numpy as np

--- a/src/nisarqa/utils/tiling.py
+++ b/src/nisarqa/utils/tiling.py
@@ -727,8 +727,6 @@ def compute_az_spectra_by_tiling(
 
     To reduce processing time, users can decrease the interval of `col_indices`.
     """
-    log = nisarqa.get_logger()
-
     arr_shape = np.shape(arr)
     if len(arr_shape) != 2:
         raise ValueError(

--- a/src/nisarqa/utils/tiling.py
+++ b/src/nisarqa/utils/tiling.py
@@ -264,6 +264,7 @@ class SubBlock2D:
         return self._arr[tile_rowslice0, tile_colslice0]
 
 
+@nisarqa.log_function_start_and_stop_time
 def compute_multilooked_backscatter_by_tiling(
     arr, nlooks, input_raster_represents_power=False, tile_shape=(512, -1)
 ):
@@ -407,6 +408,7 @@ def compute_multilooked_backscatter_by_tiling(
     return multilook_img
 
 
+@nisarqa.log_function_start_and_stop_time
 def compute_histogram_by_tiling(
     arr: ArrayLike,
     bin_edges: np.ndarray,
@@ -570,6 +572,7 @@ def compute_histogram_by_tiling(
     return hist_counts
 
 
+@nisarqa.log_function_start_and_stop_time
 def compute_range_spectra_by_tiling(
     arr: ArrayLike,
     sampling_rate: float,
@@ -670,6 +673,7 @@ def compute_range_spectra_by_tiling(
     )
 
 
+@nisarqa.log_function_start_and_stop_time
 def compute_az_spectra_by_tiling(
     arr: ArrayLike,
     sampling_rate: float,

--- a/src/nisarqa/utils/tiling.py
+++ b/src/nisarqa/utils/tiling.py
@@ -264,7 +264,6 @@ class SubBlock2D:
         return self._arr[tile_rowslice0, tile_colslice0]
 
 
-@nisarqa.log_function_start_and_stop_time
 def compute_multilooked_backscatter_by_tiling(
     arr, nlooks, input_raster_represents_power=False, tile_shape=(512, -1)
 ):
@@ -408,7 +407,6 @@ def compute_multilooked_backscatter_by_tiling(
     return multilook_img
 
 
-@nisarqa.log_function_start_and_stop_time
 def compute_histogram_by_tiling(
     arr: ArrayLike,
     bin_edges: np.ndarray,
@@ -572,7 +570,6 @@ def compute_histogram_by_tiling(
     return hist_counts
 
 
-@nisarqa.log_function_start_and_stop_time
 def compute_range_spectra_by_tiling(
     arr: ArrayLike,
     sampling_rate: float,
@@ -673,7 +670,6 @@ def compute_range_spectra_by_tiling(
     )
 
 
-@nisarqa.log_function_start_and_stop_time
 def compute_az_spectra_by_tiling(
     arr: ArrayLike,
     sampling_rate: float,

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -446,6 +446,11 @@ def log_runtime(msg: str) -> Generator[None, None, None]:
     msg : str
         Prefix for the log message. Format of logged message will be:
             "Runtime: <msg> took <duration>".
+
+    See Also
+    --------
+    log_function_runtime :
+        Function decorator to log runtime of a function.
     """
     tic = datetime.now()
     yield
@@ -465,10 +470,7 @@ def log_function_runtime(func: Callable[..., T]) -> Callable[..., T]:
     See Also
     --------
     log_runtime :
-        Context manager to log runtime with a custom message.
-        Useful if the arguments are too verbose for nice log messages.
-    log_function_runtime_with_arguments :
-        Function decorator to log a function's runtime along with its arguments.
+        Context manager to log runtime of a code block with a custom message.
     """
 
     @wraps(func)

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -15,7 +15,7 @@ from collections.abc import (
 from contextlib import contextmanager
 from datetime import datetime
 from functools import wraps
-from typing import Any, Optional, overload
+from typing import Optional, TypeVar, overload
 
 import h5py
 import numpy as np
@@ -24,6 +24,10 @@ from ruamel.yaml import YAML
 
 import nisarqa
 from nisarqa.utils.typing import RunConfigDict, T
+
+# Used for callable types
+# TODO - where in the codebase should T and P live?
+T = TypeVar("T")
 
 objects_to_skip = nisarqa.get_all(name=__name__)
 
@@ -432,56 +436,100 @@ def set_logger_handler(
         log.addHandler(handler)
 
 
-def log_function_start_and_stop_time(func):
+@contextmanager
+def log_runtime(msg: str) -> Generator[None, None, None]:
     """
-    Function decorator which logs the start and completion of a function.
+    Log the runtime of the context manager's block with microsecond precision.
 
-    Useful for benchmarking; the log file can be parsed for timings.
+    Parameters
+    ----------
+    msg : str
+        Prefix for the log message. Format of logged message will be:
+            "Runtime: <msg> took <duration>".
+    """
+    tic = datetime.now()
+    yield
+    toc = datetime.now()
+    nisarqa.get_logger().info(f"Runtime: {msg} took {toc - tic}")
 
-    The function's arguments are also logged. This may be useful for logging
-    multiple invocations of the same function with different arguments.
+
+def log_function_runtime(func: Callable[..., T]) -> Callable[..., T]:
+    """
+    Function decorator to log the runtime of a function.
+
+    Parameters
+    ----------
+    func : callable
+        Function that will have its runtime logged.
+
+    See Also
+    --------
+    log_runtime :
+        Context manager to log runtime with a custom message.
+        Useful if the arguments are too verbose for nice log messages.
+    log_function_runtime_with_arguments :
+        Function decorator to log a function's runtime along with its arguments.
     """
 
     @wraps(func)
     def wrapper(*args, **kwargs):
 
-        # Construct the "arguments" string for the log message
+        with log_runtime(f"`{func.__name__}`"):
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
+def log_function_runtime_with_arguments(
+    func: Callable[..., T],
+) -> Callable[..., T]:
+    """
+    Function decorator to log the runtime of a function and its arguments.
+
+    The function's arguments are also logged. This may be useful for logging
+    multiple invocations of the same function with different arguments.
+    If an individual argument's `repr` is longer than 100 characters, the
+    argument's value's `repr` will be used and then truncated; this is to
+    prevent e.g. large NumPy arrays from being logged.
+
+    Parameters
+    ----------
+    func : callable
+        Function that will have its runtime and arguments logged.
+
+    Warnings
+    -------
+    Logging all arguments in a log message can become very verbose.
+    Recommend testing to ensure reasonable log messages.
+
+    See Also
+    --------
+    log_runtime :
+        Context manager to log runtime with a custom message.
+        Useful if the arguments are too verbose for nice log messages.
+    log_function_runtime :
+        Function decorator to log a function's runtime, but without
+        logging the arguments.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+
         def trunc(arg) -> str:
-            max_length = 100 if isinstance(arg, nisarqa.YamlParamGroup) else 40
+            max_length = 100
             a = repr(arg)
-            if len(a) < max_length or isinstance(
-                arg, (h5py.Dataset, nisarqa.ComplexFloat16Decoder)
-            ):
+            if len(a) <= max_length:
                 return arg
             else:
                 return f"{a[:max_length]}(...)"
 
-        name = ""
-        obj_with_name_attr = (
-            h5py.Dataset,
-            nisarqa.ComplexFloat16Decoder,
-            nisarqa.Raster,
-        )
-        for a in args:
-            if isinstance(a, obj_with_name_attr):
-                name = f"{a.name}. "
-                break
-        if not name:
-            for val in kwargs.values():
-                if isinstance(val, obj_with_name_attr):
-                    name = f"{val.name}. "
-                    break
         trunc_args = tuple(trunc(i) for i in args)
         trunc_kwargs = {key: trunc(val) for key, val in kwargs.items()}
 
-        suffix = f"Called `{func.__name__}` with args={trunc_args} and kwargs={trunc_kwargs}."
+        suffix = f"`{func.__name__}` with args={trunc_args} and kwargs={trunc_kwargs}"
 
-        # Log the start, run the function, log completion, return the results
-        log = nisarqa.get_logger()
-        log.info(f"Starting function: {suffix}")
-        result = func(*args, **kwargs)
-        log.info(f"Function complete: {suffix}")
-        return result
+        with log_runtime(suffix):
+            return func(*args, **kwargs)
 
     return wrapper
 

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -15,7 +15,7 @@ from collections.abc import (
 from contextlib import contextmanager
 from datetime import datetime
 from functools import wraps
-from typing import Optional, TypeVar, overload
+from typing import Optional, overload
 
 import h5py
 import numpy as np
@@ -24,10 +24,6 @@ from ruamel.yaml import YAML
 
 import nisarqa
 from nisarqa.utils.typing import RunConfigDict, T
-
-# Used for callable types
-# TODO - where in the codebase should T and P live?
-T = TypeVar("T")
 
 objects_to_skip = nisarqa.get_all(name=__name__)
 
@@ -458,7 +454,9 @@ def log_runtime(msg: str) -> Generator[None, None, None]:
     nisarqa.get_logger().info(f"Runtime: {msg} took {toc - tic}")
 
 
-def log_function_runtime(func: Callable[..., T]) -> Callable[..., T]:
+def log_function_runtime(
+    func: Callable[..., nisarqa.T],
+) -> Callable[..., nisarqa.T]:
     """
     Function decorator to log the runtime of a function.
 

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -457,28 +457,6 @@ def log_runtime(msg: str) -> Generator[None, None, None]:
     nisarqa.get_logger().info(f"Runtime: {msg} took {toc - tic}")
 
 
-@contextmanager
-def log_runtime(msg: str) -> Generator[None, None, None]:
-    """
-    Log the runtime of the context manager's block with microsecond precision.
-
-    Parameters
-    ----------
-    msg : str
-        Prefix for the log message. Format of logged message will be:
-            "Runtime: <msg> took <duration>".
-
-    See Also
-    --------
-    log_function_runtime :
-        Function decorator to log runtime of a function.
-    """
-    tic = datetime.now()
-    yield
-    toc = datetime.now()
-    nisarqa.get_logger().info(f"Runtime: {msg} took {toc - tic}")
-
-
 def log_function_runtime(func: Callable[..., T]) -> Callable[..., T]:
     """
     Function decorator to log the runtime of a function.
@@ -529,7 +507,7 @@ def load_user_runconfig(
 
     Returns
     -------
-    user_rncfg : nisarqa.utils.typing.RunConfigDict
+    user_rncfg : nisarqa.typing.RunConfigDict
         `runconfig_yaml` loaded into a dict format
     """
     # parse runconfig into a dict structure

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -650,6 +650,34 @@ def pairwise(iterable: Iterable[T]) -> Generator[tuple[T, T], None, None]:
         a = b
 
 
+def make_scratch_directory(dir_: str | os.PathLike | None = None) -> Path:
+    """
+    Create a scratch directory as though by `tempfile.mkdtemp()`.
+
+    Parameters
+    ----------
+    dir_ : path-like or None, optional
+        Scratch directory path.
+        If `dir_` is a path-like object, a directory will be created at the
+        specified file system path if it did not already exist.
+        If `dir_` is None, a temporary directory will be created as though by
+        `tempfile.mkdtemp()`.
+        Defaults to None.
+
+    Returns
+    -------
+    pathlib.Path
+        Scratch directory path.
+    """
+    if dir_ is None:
+        scratchdir = Path(tempfile.mkdtemp())
+    else:
+        scratchdir = Path(dir_)
+        scratchdir.mkdir(parents=True, exist_ok=True)
+
+    return scratchdir
+
+
 @contextmanager
 def scratch_directory(
     dir_: str | os.PathLike | None = None, *, delete: bool = True
@@ -682,16 +710,15 @@ def scratch_directory(
     Even if `dir_` previously existed on the file system, if `delete` is True,
     then `dir_` will be deleted.
     """
-    if dir_ is None:
-        scratchdir = Path(tempfile.mkdtemp())
-    else:
-        scratchdir = Path(dir_)
-        scratchdir.mkdir(parents=True, exist_ok=True)
+    scratchdir = make_scratch_directory(dir_=dir_)
 
-    yield scratchdir
-
-    if delete:
-        shutil.rmtree(scratchdir)
+    try:
+        yield scratchdir
+    except Exception:
+        raise
+    finally:
+        if delete:
+            shutil.rmtree(scratchdir)
 
 
 def make_scratch_file(

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -436,8 +436,10 @@ def log_function_start_and_stop_time(func):
     """
     Function decorator which logs the start and completion of a function.
 
-    The function's arguments are also logged. Useful for benchmarking; the
-    log file can be parsed for timings.
+    Useful for benchmarking; the log file can be parsed for timings.
+    
+    The function's arguments are also logged. This may be useful for logging
+    multiple invocations of the same function with different arguments.
     """
 
     @wraps(func)
@@ -445,16 +447,14 @@ def log_function_start_and_stop_time(func):
 
         # Construct the "arguments" string for the log message
         def trunc(arg) -> str:
-            max_length = 40
-            if isinstance(arg, nisarqa.YamlParamGroup):
-                max_length = 100
-            a = f"{arg!r}"
+            max_length = 100 if isinstance(arg, nisarqa.YamlParamGroup) else 40
+            a = repr(arg)
             if len(a) < max_length or isinstance(
                 arg, (h5py.Dataset, nisarqa.ComplexFloat16Decoder)
             ):
                 return arg
             else:
-                return f"{a[:max_length]}[TRUNCATED]"
+                return f"{a[:max_length]}(...)"
 
         name = ""
         obj_with_name_attr = (
@@ -471,10 +471,10 @@ def log_function_start_and_stop_time(func):
                 if isinstance(val, obj_with_name_attr):
                     name = f"{val.name}. "
                     break
-        trunc_args = tuple((trunc(i) for i in args))
+        trunc_args = tuple(trunc(i) for i in args)
         trunc_kwargs = {key: trunc(val) for key, val in kwargs.items()}
 
-        suffix = f"`{func.__name__}`. {name}args={trunc_args}. kwargs={trunc_kwargs}."
+        suffix = f"Called `{func.__name__}` with args={trunc_args} and kwargs={trunc_kwargs}."
 
         # Log the start, run the function, log completion, return the results
         log = nisarqa.get_logger()

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -650,9 +650,9 @@ def pairwise(iterable: Iterable[T]) -> Generator[tuple[T, T], None, None]:
         a = b
 
 
-def make_scratch_directory(dir_: str | os.PathLike | None = None) -> Path:
+def _create_scratch_directory(dir_: str | os.PathLike | None = None) -> Path:
     """
-    Create a scratch directory as though by `tempfile.mkdtemp()`.
+    Prepare the scratch directory and return the absolute path.
 
     Parameters
     ----------
@@ -666,24 +666,28 @@ def make_scratch_directory(dir_: str | os.PathLike | None = None) -> Path:
 
     Returns
     -------
-    pathlib.Path
-        Scratch directory path.
+    path : pathlib.Path
+        Absolute path to the scratch directory.
     """
     if dir_ is None:
-        scratchdir = Path(tempfile.mkdtemp())
+        path = Path(tempfile.mkdtemp())
     else:
-        scratchdir = Path(dir_)
-        scratchdir.mkdir(parents=True, exist_ok=True)
+        path = Path(dir_)
+        path.mkdir(parents=True, exist_ok=True)
 
-    return scratchdir
+    # Expand ~ to the user’s home directory. Make path an absolute path.
+    # Also resolves symlinks (if they exist).
+    path = path.expanduser().resolve()
+
+    return path
 
 
 @contextmanager
-def scratch_directory(
+def scratch_directory_manager(
     dir_: str | os.PathLike | None = None, *, delete: bool = True
 ) -> Generator[Path, None, None]:
     """
-    Context manager that creates a (possibly temporary) file system directory.
+    Context manager for a (possibly temporary) file system directory.
 
     Parameters
     ----------
@@ -710,17 +714,121 @@ def scratch_directory(
     Even if `dir_` previously existed on the file system, if `delete` is True,
     then `dir_` will be deleted.
     """
-    scratchdir = make_scratch_directory(dir_=dir_)
+    set_global_scratch(scratch_dir=dir_)
+    scratchdir = get_global_scratch()
 
     try:
         yield scratchdir
     except Exception:
         raise
     finally:
+        log = nisarqa.get_logger()
+        current_scratch = get_global_scratch()
+
+        if scratchdir != current_scratch:
+            msg = (
+                f"Global scratch directory was '{scratchdir}', but it was"
+                f" most-recently updated to '{current_scratch}' external to"
+                " (but within the context of) this context manager."
+            )
+            if delete:
+                msg += (
+                    f" Only original scratch directory '{scratchdir}'"
+                    " will be deleted."
+                )
+            log.warning(msg)
+
         if delete:
-            shutil.rmtree(scratchdir)
+            try:
+                shutil.rmtree(scratchdir)
+            except FileNotFoundError:
+                msg = (
+                    f"Global scratch directory was '{scratchdir}', but it was"
+                    " deleted external to (but within the context of)"
+                    " this context manager."
+                )
+                log.error(msg)
+                raise FileNotFoundError(msg)
+            else:
+                log.info(
+                    f"Scratch directory deleted recursively: '{scratchdir}'"
+                )
 
 
+def set_global_scratch(scratch_dir: str | os.PathLike | None = None) -> None:
+    """
+    Set the persistent global scratch directory path.
+
+    For subsequent call to this function, the stored path is updated.
+
+    If the path does not exist, it is created (including parent directories).
+
+    Parameters
+    ----------
+    scratch_dir : path-like or None
+        If `scratch_dir` is a path-like object, the directory (with parents)
+        will created if it does not already exist.
+        If `scratch_dir` is None, a new temporary directory will be created as
+        though by `tempfile.mkdtemp()`.
+        The user is responsible for deleting the cache directory and its
+        contents when done with it.
+        Defaults to None.
+
+    See Also
+    --------
+    get_global_scratch :
+        After the global scratch directory has been set, use this function
+        to get the absolute Path to the global scratch directory.
+    """
+    log = nisarqa.get_logger()
+    scratch_path = _create_scratch_directory(dir_=scratch_dir)
+
+    if (
+        hasattr(set_global_scratch, "_scratch_path")
+        and set_global_scratch._scratch_path == scratch_path
+    ):
+        old_dir = set_global_scratch._scratch_path
+        log.info(
+            f"Global scratch directory path was '{old_dir}'."
+            f" Updating it to '{scratch_path}'."
+        )
+
+    # Set function attribute to the globale scratch path
+    set_global_scratch._scratch_path = scratch_path
+
+    log.info(
+        f"Global scratch directory path set to '{set_global_scratch._scratch_path}'."
+    )
+
+
+def get_global_scratch() -> Path:
+    """
+    Get the persistent global scratch directory path.
+
+    User must call `set_global_scratch()` prior to calling this function.
+
+    Returns
+    -------
+    path : pathlib.Path
+        Path to global scratch directory.
+
+    See Also
+    --------
+    set_global_scratch :
+        Set the global scratch directory. Must be called prior to calling
+        `get_global_scratch()`.
+    """
+
+    if not hasattr(set_global_scratch, "_scratch_path"):
+        raise ValueError(
+            "Scratch path not set. User must call `set_global_scratch()`"
+            " prior to calling this function."
+        )
+
+    return getattr(set_global_scratch, "_scratch_path")
+
+
+# TODO delete this function if unused
 def make_scratch_file(
     *,
     dir_: os.PathLike | str | None = None,
@@ -752,54 +860,6 @@ def make_scratch_file(
     file, filename = tempfile.mkstemp(dir=dir_, prefix=prefix, suffix=suffix)
     os.close(file)
     return Path(filename)
-
-
-class VerifyFunc(Protocol, Generic[T]):
-    def __call__(
-        self,
-        root_params: nisarqa.NonInsarRootParamGroup,
-        *args: Any,
-        **kwargs: Any,
-    ) -> T: ...
-
-
-def prep_scratch_dir_from_root_params(
-    func: VerifyFunc[T],
-) -> VerifyFunc[T]:
-    """
-    Function decorator to handle setup and cleanup of a scratch directory.
-
-    Parameters
-    ----------
-    func : nisarqa.VerifyFunc
-        Function that will be wrapped. Per the nisarqa.VerifyFunc Protocol,
-        `func`'s first argument must be a root parameter group. This decorator
-        will parse the scratch directory path name and the user's request
-        of whether or not to cleanup the scratch directory after `func` has
-        finished from this root parameter group.
-
-    Returns
-    -------
-    wrapped_func : nisarqa.VerifyFunc
-        `func` that has been wrapped.
-    """
-
-    @wraps(func)
-    def wrapped_func(*args, **kwargs):
-        if len(args) > 0 and isinstance(
-            args[0], nisarqa.NonInsarRootParamGroup
-        ):
-            root_params = args[0]
-        else:
-            root_params = kwargs["root_params"]
-        qa_scratch_dir = root_params.prodpath.scratch_dir
-
-        delete = root_params.software_config.delete_scratch_dir
-
-        with scratch_directory(dir_=qa_scratch_dir, delete=delete):
-            return func(*args, **kwargs)
-
-    return wrapped_func
 
 
 __all__ = nisarqa.get_all(__name__, objects_to_skip)

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 import math
 import os
@@ -16,9 +17,9 @@ from collections.abc import (
 )
 from contextlib import contextmanager
 from datetime import datetime
-from functools import wraps
+from functools import lru_cache, wraps
 from pathlib import Path
-from typing import Optional, overload
+from typing import Any, Callable, Optional, overload
 
 import h5py
 import numpy as np
@@ -794,6 +795,76 @@ def get_global_scratch() -> Path:
         )
 
     return getattr(set_global_scratch, "_scratch_path")
+
+
+def lru_cache_with_frozen_argument(
+    param_name: str,
+) -> Callable[[Callable[..., qa_typing.T]], Callable[..., qa_typing.T]]:
+    """
+    Decorator akin to `functools.lru_cache` but with one frozen argument.
+
+    Decorator to cache a function using LRU caching and freeze one argument
+    after the first call. On subsequent calls, the specified argument is always
+    overridden with the frozen value, even if a different value is passed.
+
+    This decorator uses `functools.lru_cache`, so all caveats about
+    threadsafe executions, argument patterns, argument types, etc. apply here.
+    See: https://docs.python.org/3/library/functools.html#functools.lru_cache
+
+    Parameters
+    ----------
+    param_name : str
+        The name of one of the decorated function's parameters, whose argument
+        will be frozen after the first invocation.
+    """
+
+    def decorator(
+        func: Callable[..., qa_typing.T],
+    ) -> Callable[..., qa_typing.T]:
+
+        frozen_value: dict[str, Any] = {}  # Stores the frozen argument value
+        sig = inspect.signature(func)  # Used to bind arguments by name
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            # Bind positional and keyword arguments to named parameters
+            # https://docs.python.org/3/library/inspect.html#inspect.BoundArguments
+            bound_args = sig.bind(*args, **kwargs)
+            # Apply default values where needed
+            bound_args.apply_defaults()
+
+            if param_name not in bound_args.arguments:
+                raise ValueError(
+                    f"Requested parameter to be frozen is '{param_name}',"
+                    " but must be one of the wrapped function's parameters:"
+                    f" {list(bound_args.arguments.keys())} "
+                )
+
+            new_val = bound_args.arguments[param_name]
+
+            if "value" not in frozen_value:
+                # On first call, freeze the value
+                frozen_value["value"] = new_val
+            else:
+                # Override the provided argument value with the frozen one
+                frz_val = frozen_value["value"]
+                nisarqa.get_logger().debug(
+                    f"Overriding argument for '{param_name}': received"
+                    f" `{new_val}`, using persistent frozen value `{frz_val}`"
+                )
+                bound_args.arguments[param_name] = frz_val
+
+            # Call the cached function with possibly modified arguments
+            return cached_func(*bound_args.args, **bound_args.kwargs)
+
+        # Apply LRU caching to the original function
+        # The result is a new function `cached_func` that behaves identically
+        # to func, but it remembers previous calls based on the argument values.
+        cached_func = lru_cache()(func)
+
+        return wrapper
+
+    return decorator
 
 
 __all__ = nisarqa.get_all(__name__, objects_to_skip)

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -437,7 +437,7 @@ def log_function_start_and_stop_time(func):
     Function decorator which logs the start and completion of a function.
 
     Useful for benchmarking; the log file can be parsed for timings.
-    
+
     The function's arguments are also logged. This may be useful for logging
     multiple invocations of the same function with different arguments.
     """

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -432,6 +432,60 @@ def set_logger_handler(
         log.addHandler(handler)
 
 
+def log_function_start_and_stop_time(func):
+    """
+    Function decorator which logs the start and completion of a function.
+
+    The function's arguments are also logged. Useful for benchmarking; the
+    log file can be parsed for timings.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+
+        # Construct the "arguments" string for the log message
+        def trunc(arg) -> str:
+            max_length = 40
+            if isinstance(arg, nisarqa.YamlParamGroup):
+                max_length = 100
+            a = f"{arg!r}"
+            if len(a) < max_length or isinstance(
+                arg, (h5py.Dataset, nisarqa.ComplexFloat16Decoder)
+            ):
+                return arg
+            else:
+                return f"{a[:max_length]}[TRUNCATED]"
+
+        name = ""
+        obj_with_name_attr = (
+            h5py.Dataset,
+            nisarqa.ComplexFloat16Decoder,
+            nisarqa.Raster,
+        )
+        for a in args:
+            if isinstance(a, obj_with_name_attr):
+                name = f"{a.name}. "
+                break
+        if not name:
+            for val in kwargs.values():
+                if isinstance(val, obj_with_name_attr):
+                    name = f"{val.name}. "
+                    break
+        trunc_args = tuple((trunc(i) for i in args))
+        trunc_kwargs = {key: trunc(val) for key, val in kwargs.items()}
+
+        suffix = f"`{func.__name__}`. {name}args={trunc_args}. kwargs={trunc_kwargs}."
+
+        # Log the start, run the function, log completion, return the results
+        log = nisarqa.get_logger()
+        log.info(f"Starting function: {suffix}")
+        result = func(*args, **kwargs)
+        log.info(f"Function complete: {suffix}")
+        return result
+
+    return wrapper
+
+
 @contextmanager
 def log_runtime(msg: str) -> Generator[None, None, None]:
     """

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -626,7 +626,7 @@ def pairwise(iterable: Iterable[T]) -> Generator[tuple[T, T], None, None]:
 
 def _create_scratch_directory(dir_: str | os.PathLike | None = None) -> Path:
     """
-    Prepare the scratch directory and return the absolute path.
+    Prepare the scratch directory and return the path.
 
     Parameters
     ----------
@@ -641,17 +641,13 @@ def _create_scratch_directory(dir_: str | os.PathLike | None = None) -> Path:
     Returns
     -------
     path : pathlib.Path
-        Absolute path to the scratch directory.
+        Path to the scratch directory.
     """
     if dir_ is None:
         path = Path(tempfile.mkdtemp())
     else:
         path = Path(dir_)
         path.mkdir(parents=True, exist_ok=True)
-
-    # Expand ~ to the user’s home directory. Make path an absolute path.
-    # Also resolves symlinks (if they exist).
-    path = path.expanduser().resolve()
 
     return path
 
@@ -693,8 +689,6 @@ def scratch_directory_manager(
 
     try:
         yield scratchdir
-    except Exception:
-        raise
     finally:
         log = nisarqa.get_logger()
         current_scratch = get_global_scratch()
@@ -752,7 +746,7 @@ def set_global_scratch(scratch_dir: str | os.PathLike | None = None) -> None:
     --------
     get_global_scratch :
         After the global scratch directory has been set, use this function
-        to get the absolute Path to the global scratch directory.
+        to get the Path to the global scratch directory.
     """
     log = nisarqa.get_logger()
     scratch_path = _create_scratch_directory(dir_=scratch_dir)

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 import math
 import os
+import shutil
+import tempfile
 import warnings
 from collections.abc import (
     Callable,
@@ -15,7 +17,8 @@ from collections.abc import (
 from contextlib import contextmanager
 from datetime import datetime
 from functools import wraps
-from typing import Optional, overload
+from pathlib import Path
+from typing import Any, Generic, Optional, Protocol, overload
 
 import h5py
 import numpy as np
@@ -645,6 +648,132 @@ def pairwise(iterable: Iterable[T]) -> Generator[tuple[T, T], None, None]:
     for b in iterator:
         yield a, b
         a = b
+
+
+@contextmanager
+def scratch_directory(
+    dir_: str | os.PathLike | None = None, *, delete: bool = True
+) -> Generator[Path, None, None]:
+    """
+    Context manager that creates a (possibly temporary) file system directory.
+
+    Parameters
+    ----------
+    dir_ : path-like or None, optional
+        Scratch directory path.
+        If `dir_` is a path-like object, a directory will be created at the
+        specified file system path if it did not already exist.
+        If `dir_` is None, a temporary directory will be created as though by
+        `tempfile.mkdtemp()`.
+        Defaults to None.
+    delete : bool, optional
+        If True, the directory and its contents are recursively removed from the
+        file system upon exiting the context manager.
+        Defaults to True.
+
+    Yields
+    ------
+    pathlib.Path
+        Scratch directory path. If `delete` was True, the directory will be
+        removed from the file system upon exiting the context manager scope.
+
+    Warnings
+    --------
+    Even if `dir_` previously existed on the file system, if `delete` is True,
+    then `dir_` will be deleted.
+    """
+    if dir_ is None:
+        scratchdir = Path(tempfile.mkdtemp())
+    else:
+        scratchdir = Path(dir_)
+        scratchdir.mkdir(parents=True, exist_ok=True)
+
+    yield scratchdir
+
+    if delete:
+        shutil.rmtree(scratchdir)
+
+
+# TODO - delete this function during code review if it remains unused
+def make_scratch_file(
+    *,
+    dir_: os.PathLike | str | None = None,
+    prefix: str | None = None,
+    suffix: str | None = None,
+) -> Path:
+    """
+    Create a uniquely-named scratch filepath as though by `tempfile.mkstemp()`.
+
+    Parameters
+    ----------
+    dir_ : path-like or None, optional
+        If dir_ is not None, the file will be created in that directory.
+        Otherwise, a default directory is used per `tempfile.mkstemp()`:
+        https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp
+        Defaults to None.
+    prefix, suffix : str or None, optional
+        Prefix and suffix for the scratch file, as per `tempfile.mkstemp()`:
+        https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp
+        Defaults to None.
+
+    Returns
+    -------
+    path : pathlib.Path
+        Filepath to a uniquely-named scratch file.
+    """
+    if dir_ is not None:
+        dir_ = os.fsdecode(dir_)
+    file, filename = tempfile.mkstemp(dir=dir_, prefix=prefix, suffix=suffix)
+    os.close(file)
+    return Path(filename)
+
+
+class VerifyFunc(Protocol, Generic[T]):
+    def __call__(
+        self,
+        root_params: nisarqa.NonInsarRootParamGroup,
+        *args: Any,
+        **kwargs: Any,
+    ) -> T: ...
+
+
+def prep_scratch_dir_from_root_params(
+    func: VerifyFunc[T],
+) -> VerifyFunc[T]:
+    """
+    Function decorator to handle setup and cleanup of a scratch directory.
+
+    Parameters
+    ----------
+    func : nisarqa.VerifyFunc
+        Function that will be wrapped. Per the nisarqa.VerifyFunc Protocol,
+        `func`'s first argument must be a root parameter group. This decorator
+        will parse the scratch directory path name and the user's request
+        of whether or not to cleanup the scratch directory after `func` has
+        finished from this root parameter group.
+
+    Returns
+    -------
+    wrapped_func : nisarqa.VerifyFunc
+        `func` that has been wrapped.
+    """
+
+    @wraps(func)
+    def wrapped_func(*args, **kwargs):
+        if len(args) > 0 and isinstance(
+            args[0], nisarqa.NonInsarRootParamGroup
+        ):
+            root_params = args[0]
+        else:
+            root_params = kwargs["root_params"]
+        qa_scratch_dir = root_params.prodpath.scratch_dir
+
+        delete = root_params.software_config.delete_scratch_dir
+
+        with scratch_directory(dir_=qa_scratch_dir, delete=delete):
+            return func(*args, **kwargs)
+
+    return wrapped_func
 
 
 __all__ = nisarqa.get_all(__name__, objects_to_skip)

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -637,8 +637,8 @@ def create_unique_subdirectory(
     Parameters
     ----------
     parent_dir : path-like or None, optional
-        Path for a local directory where a new, uniquely-named subdirectory
-        will be created.
+        Local file system path to a directory where a new, uniquely-named
+        subdirectory will be created.
         If `parent_dir` is a path-like object, it will be created if it
         did not already exist.
         If `parent_dir` is None, a temporary directory will be created as
@@ -707,10 +707,10 @@ def set_global_scratch_dir(scratch_dir: str | os.PathLike) -> None:
 
     Parameters
     ----------
-    scratch_dir : path-like or None
-        Path to the scratch directory. The user is responsible for
-        deleting the scratch directory and its contents when done with it.
-        Defaults to None.
+    scratch_dir : path-like
+        Path to the scratch directory. Must be an existing directory
+        in the local file system. The user is responsible for deleting
+        the scratch directory and its contents when done with it.
 
     See Also
     --------
@@ -720,7 +720,9 @@ def set_global_scratch_dir(scratch_dir: str | os.PathLike) -> None:
     """
     log = nisarqa.get_logger()
 
-    if not Path(scratch_dir).is_dir():
+    path = Path(scratch_dir)
+
+    if not path.is_dir():
         raise ValueError(f"{scratch_dir=}, must be an existing directory.")
 
     # Log if the global scratch directory already existed and is being updated.
@@ -728,11 +730,11 @@ def set_global_scratch_dir(scratch_dir: str | os.PathLike) -> None:
         old_dir = set_global_scratch_dir._scratch_dir
         log.info(
             f"Global scratch directory path was '{old_dir}'."
-            f" Updating it to '{scratch_dir}'."
+            f" Updating it to '{path}'."
         )
 
     # Set function attribute to the new global scratch path
-    set_global_scratch_dir._scratch_dir = scratch_dir
+    set_global_scratch_dir._scratch_dir = path
 
     log.info(
         f"Global scratch directory path set to "

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 import logging
 import math
 import os
@@ -17,9 +16,9 @@ from collections.abc import (
 )
 from contextlib import contextmanager
 from datetime import datetime
-from functools import lru_cache, wraps
+from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, Optional, overload
+from typing import Callable, Optional, overload
 
 import h5py
 import numpy as np
@@ -795,76 +794,6 @@ def get_global_scratch() -> Path:
         )
 
     return getattr(set_global_scratch, "_scratch_path")
-
-
-def lru_cache_with_frozen_argument(
-    param_name: str,
-) -> Callable[[Callable[..., qa_typing.T]], Callable[..., qa_typing.T]]:
-    """
-    Decorator akin to `functools.lru_cache` but with one frozen argument.
-
-    Decorator to cache a function using LRU caching and freeze one argument
-    after the first call. On subsequent calls, the specified argument is always
-    overridden with the frozen value, even if a different value is passed.
-
-    This decorator uses `functools.lru_cache`, so all caveats about
-    threadsafe executions, argument patterns, argument types, etc. apply here.
-    See: https://docs.python.org/3/library/functools.html#functools.lru_cache
-
-    Parameters
-    ----------
-    param_name : str
-        The name of one of the decorated function's parameters, whose argument
-        will be frozen after the first invocation.
-    """
-
-    def decorator(
-        func: Callable[..., qa_typing.T],
-    ) -> Callable[..., qa_typing.T]:
-
-        frozen_value: dict[str, Any] = {}  # Stores the frozen argument value
-        sig = inspect.signature(func)  # Used to bind arguments by name
-
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            # Bind positional and keyword arguments to named parameters
-            # https://docs.python.org/3/library/inspect.html#inspect.BoundArguments
-            bound_args = sig.bind(*args, **kwargs)
-            # Apply default values where needed
-            bound_args.apply_defaults()
-
-            if param_name not in bound_args.arguments:
-                raise ValueError(
-                    f"Requested parameter to be frozen is '{param_name}',"
-                    " but must be one of the wrapped function's parameters:"
-                    f" {list(bound_args.arguments.keys())} "
-                )
-
-            new_val = bound_args.arguments[param_name]
-
-            if "value" not in frozen_value:
-                # On first call, freeze the value
-                frozen_value["value"] = new_val
-            else:
-                # Override the provided argument value with the frozen one
-                frz_val = frozen_value["value"]
-                nisarqa.get_logger().debug(
-                    f"Overriding argument for '{param_name}': received"
-                    f" `{new_val}`, using persistent frozen value `{frz_val}`"
-                )
-                bound_args.arguments[param_name] = frz_val
-
-            # Call the cached function with possibly modified arguments
-            return cached_func(*bound_args.args, **bound_args.kwargs)
-
-        # Apply LRU caching to the original function
-        # The result is a new function `cached_func` that behaves identically
-        # to func, but it remembers previous calls based on the argument values.
-        cached_func = lru_cache()(func)
-
-        return wrapper
-
-    return decorator
 
 
 __all__ = nisarqa.get_all(__name__, objects_to_skip)

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -480,60 +480,6 @@ def log_function_runtime(func: Callable[..., T]) -> Callable[..., T]:
     return wrapper
 
 
-def log_function_runtime_with_arguments(
-    func: Callable[..., T],
-) -> Callable[..., T]:
-    """
-    Function decorator to log the runtime of a function and its arguments.
-
-    The function's arguments are also logged. This may be useful for logging
-    multiple invocations of the same function with different arguments.
-    If an individual argument's `repr` is longer than 100 characters, the
-    argument's value's `repr` will be used and then truncated; this is to
-    prevent e.g. large NumPy arrays from being logged.
-
-    Parameters
-    ----------
-    func : callable
-        Function that will have its runtime and arguments logged.
-
-    Warnings
-    -------
-    Logging all arguments in a log message can become very verbose.
-    Recommend testing to ensure reasonable log messages.
-
-    See Also
-    --------
-    log_runtime :
-        Context manager to log runtime with a custom message.
-        Useful if the arguments are too verbose for nice log messages.
-    log_function_runtime :
-        Function decorator to log a function's runtime, but without
-        logging the arguments.
-    """
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-
-        def trunc(arg) -> str:
-            max_length = 100
-            a = repr(arg)
-            if len(a) <= max_length:
-                return arg
-            else:
-                return f"{a[:max_length]}(...)"
-
-        trunc_args = tuple(trunc(i) for i in args)
-        trunc_kwargs = {key: trunc(val) for key, val in kwargs.items()}
-
-        suffix = f"`{func.__name__}` with args={trunc_args} and kwargs={trunc_kwargs}"
-
-        with log_runtime(suffix):
-            return func(*args, **kwargs)
-
-    return wrapper
-
-
 @contextmanager
 def log_runtime(msg: str) -> Generator[None, None, None]:
     """

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -694,7 +694,6 @@ def scratch_directory(
         shutil.rmtree(scratchdir)
 
 
-# TODO - delete this function during code review if it remains unused
 def make_scratch_file(
     *,
     dir_: os.PathLike | str | None = None,

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -669,11 +669,11 @@ def create_unique_subdirectory(
         # Create a uniquely-named subdirectory
         utc_now = datetime.now(timezone.utc)
         # The colon character `:` is not advised for POSIX paths
-        utc_now = utc_now.strftime("%Y-%m-%dT%Hh%Mm%SsZ")
-        prefix_str = "" if prefix is None else prefix
-        path = Path(parent_dir) / f"{prefix_str}{utc_now}-{uuid.uuid4()}"
+        utc_now = utc_now.strftime("%Y%m%d%H%M%S")
 
-        path.mkdir(parents=True, exist_ok=True)
+        prefix_str = f"{'' if prefix is None else (prefix + '-')}{utc_now}-"
+
+        path = Path(tempfile.mkdtemp(prefix=prefix_str, dir=parent_dir))
 
     try:
         yield path

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -18,7 +18,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from functools import wraps
 from pathlib import Path
-from typing import Any, Generic, Optional, Protocol, overload
+from typing import Optional, overload
 
 import h5py
 import numpy as np
@@ -457,32 +457,6 @@ def log_runtime(msg: str) -> Generator[None, None, None]:
     nisarqa.get_logger().info(f"Runtime: {msg} took {toc - tic}")
 
 
-def log_function_runtime(
-    func: Callable[..., nisarqa.T],
-) -> Callable[..., nisarqa.T]:
-    """
-    Function decorator to log the runtime of a function.
-
-    Parameters
-    ----------
-    func : callable
-        Function that will have its runtime logged.
-
-    See Also
-    --------
-    log_runtime :
-        Context manager to log runtime of a code block with a custom message.
-    """
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-
-        with log_runtime(f"`{func.__name__}`"):
-            return func(*args, **kwargs)
-
-    return wrapper
-
-
 @contextmanager
 def log_runtime(msg: str) -> Generator[None, None, None]:
     """
@@ -826,40 +800,6 @@ def get_global_scratch() -> Path:
         )
 
     return getattr(set_global_scratch, "_scratch_path")
-
-
-# TODO delete this function if unused
-def make_scratch_file(
-    *,
-    dir_: os.PathLike | str | None = None,
-    prefix: str | None = None,
-    suffix: str | None = None,
-) -> Path:
-    """
-    Create a uniquely-named scratch filepath as though by `tempfile.mkstemp()`.
-
-    Parameters
-    ----------
-    dir_ : path-like or None, optional
-        If dir_ is not None, the file will be created in that directory.
-        Otherwise, a default directory is used per `tempfile.mkstemp()`:
-        https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp
-        Defaults to None.
-    prefix, suffix : str or None, optional
-        Prefix and suffix for the scratch file, as per `tempfile.mkstemp()`:
-        https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp
-        Defaults to None.
-
-    Returns
-    -------
-    path : pathlib.Path
-        Filepath to a uniquely-named scratch file.
-    """
-    if dir_ is not None:
-        dir_ = os.fsdecode(dir_)
-    file, filename = tempfile.mkstemp(dir=dir_, prefix=prefix, suffix=suffix)
-    os.close(file)
-    return Path(filename)
 
 
 __all__ = nisarqa.get_all(__name__, objects_to_skip)


### PR DESCRIPTION
Previously, all QA workflows read imagery Datasets directly from input HDF5 file for every feature. For example, after RSLC et al updated the baseline storage format for the imagery Datasets from uncompressed complex float16 to compressed complex float32, the QA runtime for RSLC increased from ~3-4min to ~10-15min for large Datasets.

The primary purpose of this PR is to `memmap` the primary imagery datasets one time (for the first read) and then store/access that memmap for subsequent reads. This enables significant speedup of processing, bringing the total runtime for RSLC compressed complex float32 datasets down to ~3min.

GSLC and GCOV use similar QA code as RSLC, so with minimal extra code in this PR, we should see speedup for them "for free".

The other significant addition to this PR is that QA has learned about the scratch directory, so that there is a known place to store the memmap's. Most of the code changes are a result of adding the scratch directory.

Note: This PR builds on https://github.com/nemo794/nisarqa/pull/1/commits