### PR TITLE
Bugfix: Connected Components metrics and colorbar interval

### DIFF
--- a/src/nisarqa/utils/calc.py
+++ b/src/nisarqa/utils/calc.py
@@ -738,11 +738,12 @@ def connected_components_metrics(
     )
 
     # Percentage of pixels in largest connected component
+    percent_largest_cc = 0.0 if num_valid_cc == 0 else max(percentages_list)
     nisarqa.create_dataset_in_h5group(
         h5_file=stats_h5,
         grp_path=grp_path,
         ds_name="percentPixelsInLargestCC",
-        ds_data=max(percentages_list),
+        ds_data=percent_largest_cc,
         ds_units="1",
         ds_description=(
             "Percentage of pixels in the largest valid connected component"
@@ -753,11 +754,12 @@ def connected_components_metrics(
     )
 
     # Percentage of pixels with non-zero, non-fill connected components
+    percent_non_zero_cc = 0.0 if num_valid_cc == 0 else sum(percentages_list)
     nisarqa.create_dataset_in_h5group(
         h5_file=stats_h5,
         grp_path=grp_path,
         ds_name="percentPixelsWithNonZeroCC",
-        ds_data=sum(percentages_list),
+        ds_data=percent_non_zero_cc,
         ds_units="1",
         ds_description=(
             "Percentage of pixels with non-zero, non-fill connected components"

--- a/src/nisarqa/utils/plotting.py
+++ b/src/nisarqa/utils/plotting.py
@@ -1756,8 +1756,15 @@ def format_cbar_ticks_for_multiples_of_pi(
             " matplotlib.colorbar.Colorbar or matplotlib.axes.Axes."
         )
 
+    if np.isclose(
+            cbar_max, cbar_max, atol=1e-6, rtol=0.0
+        ):
+        nisarqa.get_logger().warning(
+            f"{cbar_max=} and {cbar_min=}, which are approximately equal."
+            " Suggest double-checking datasets are as expected."
+        )
     # To be NaN-safe, do not simply use `if cbar_max <= cbar_min`.
-    if not (cbar_max > cbar_min):
+    elif not (cbar_max > cbar_min):
         raise ValueError(
             f"cbar_max must be > cbar_min, but got {cbar_max=} and {cbar_min=}."
         )

--- a/src/nisarqa/utils/plotting.py
+++ b/src/nisarqa/utils/plotting.py
@@ -1756,9 +1756,7 @@ def format_cbar_ticks_for_multiples_of_pi(
             " matplotlib.colorbar.Colorbar or matplotlib.axes.Axes."
         )
 
-    if np.isclose(
-            cbar_max, cbar_max, atol=1e-6, rtol=0.0
-        ):
+    if np.isclose(cbar_max, cbar_max, atol=1e-6, rtol=0.0):
         nisarqa.get_logger().warning(
             f"{cbar_max=} and {cbar_min=}, which are approximately equal."
             " Suggest double-checking datasets are as expected."


### PR DESCRIPTION
Two bugs were identified when running QA on RUNW and GUNW products generated from REE "noise" data, which resulted in RUNW and GUNW products without any connected components and which resulted in layers containing all ~0.0 values.

1) Bug: Exceptions raised when computing Connected Components metrics when there are no connected components.
    - Fix: In `src/nisarqa/utils/calc.py`, default values are now set for this edge case
2) Bug: Exception raised when the pixel values imagery portion of a layer are constant (e.g. all ~0.0).
    - Fix: Log a warning, but do not raise an exception. If a layer's pixels' values are approx. constant, it should be plotted.
    - Note: There are some cases where a layer is known to be all ~zero-valued. There are existing QA checks to handle these cases.