### PR TITLE
Copy input granule's `runConfigurationContents`. Modularize `STATS.h5` setup.

### DIFF
--- a/src/nisarqa/parameters/nisar_params.py
+++ b/src/nisarqa/parameters/nisar_params.py
@@ -1346,14 +1346,14 @@ class RootParamGroup(ABC):
         Parameters
         ----------
         h5_file : h5py.File
-            Handle to an h5 file where the processing metadata should be saved.
+            Handle to an HDF5 file where processing metadata should be saved.
         band : str
             The letter of the band. Ex: "L" or "S".
         """
         for params_obj in fields(self):
             po = getattr(self, params_obj.name)
             # If a workflow was not requested, its RootParams attribute
-            # will be None, so there will be no params to add to the h5 file
+            # will be None, so there will be no params to add to the HDF5 file
             if po is not None:
                 if issubclass(type(po), HDF5ParamGroup):
                     po.write_params_to_h5(h5_file, band=band)

--- a/src/nisarqa/parameters/rslc_caltools_params.py
+++ b/src/nisarqa/parameters/rslc_caltools_params.py
@@ -1079,7 +1079,7 @@ class RSLCRootParamGroup(RootParamGroup):
                 # RootParamGroup.save_processing_params_to_stats_h5():
                 #       If a workflow was not requested, its RootParams
                 #       attribute will be None, so there will be no params to
-                #       add to the h5 file."
+                #       add to the HDF5 file."
                 # In nominal cases, these groups are set to None during
                 # `from_runconfig_dict()`. But, that step occurs prior to
                 # checking whether a corner reflector file was provided,

--- a/src/nisarqa/products/gcov.py
+++ b/src/nisarqa/products/gcov.py
@@ -134,16 +134,9 @@ def verify_gcov(
             # Add file metadata and title page to report PDF.
             nisarqa.setup_report_pdf(product=product, report_pdf=report_pdf)
 
-            # Save the processing parameters to the stats.h5 file
-            root_params.save_processing_params_to_stats_h5(
-                h5_file=stats_h5, band=product.band
+            nisarqa.setup_stats_h5_all_products(
+                product=product, stats_h5=stats_h5, root_params=root_params
             )
-            log.info(f"QA Processing Parameters saved to {stats_file}")
-
-            nisarqa.copy_identification_group_to_stats_h5(
-                product=product, stats_h5=stats_h5
-            )
-            log.info(f"Input file Identification group copied to {stats_file}")
 
             # Save frequency/polarization info from `pols` to stats file
             nisarqa.save_nisar_freq_metadata_to_h5(

--- a/src/nisarqa/products/gslc.py
+++ b/src/nisarqa/products/gslc.py
@@ -103,20 +103,13 @@ def verify_gslc(
     # If running these workflows, save the processing parameters and
     # identification group to STATS.h5
     if root_params.workflows.qa_reports or root_params.workflows.point_target:
-        # This is the first time opening the STATS.h5 file for RSLC
+        # This is the first time opening the STATS.h5 file for GSLC
         # workflow, so open in 'w' mode.
         # After this, always open STATS.h5 in 'r+' mode.
         with h5py.File(stats_file, mode="w") as stats_h5:
-            # Save the processing parameters to the stats.h5 file
-            root_params.save_processing_params_to_stats_h5(
-                h5_file=stats_h5, band=product.band
+            nisarqa.setup_stats_h5_all_products(
+                product=product, stats_h5=stats_h5, root_params=root_params
             )
-            log.info(f"QA Processing Parameters saved to {stats_file}")
-
-            nisarqa.copy_identification_group_to_stats_h5(
-                product=product, stats_h5=stats_h5
-            )
-            log.info(f"Input file Identification group copied to {stats_file}")
 
     # Both the `qa_reports` and/or `point_target` steps may generate a report
     # PDF. If both are workflows are enabled, this can cause an issue, since

--- a/src/nisarqa/products/igram.py
+++ b/src/nisarqa/products/igram.py
@@ -147,16 +147,9 @@ def verify_igram(
             # Add file metadata and title page to report PDF.
             nisarqa.setup_report_pdf(product=product, report_pdf=report_pdf)
 
-            # Save the processing parameters to the stats.h5 file
-            root_params.save_processing_params_to_stats_h5(
-                h5_file=stats_h5, band=product.band
+            nisarqa.setup_stats_h5_all_products(
+                product=product, stats_h5=stats_h5, root_params=root_params
             )
-            log.info(f"QA Processing Parameters saved to {stats_file}")
-
-            nisarqa.copy_identification_group_to_stats_h5(
-                product=product, stats_h5=stats_h5
-            )
-            log.info(f"Input file Identification group copied to {stats_file}")
 
             # Save frequency/polarization info to stats file
             product.save_qa_metadata_to_h5(stats_h5=stats_h5)

--- a/src/nisarqa/products/offsets.py
+++ b/src/nisarqa/products/offsets.py
@@ -140,16 +140,9 @@ def verify_offset(
             # Add file metadata and title page to report PDF.
             nisarqa.setup_report_pdf(product=product, report_pdf=report_pdf)
 
-            # Save the processing parameters to the stats.h5 file
-            root_params.save_processing_params_to_stats_h5(
-                h5_file=stats_h5, band=product.band
+            nisarqa.setup_stats_h5_all_products(
+                product=product, stats_h5=stats_h5, root_params=root_params
             )
-            log.info(f"QA Processing Parameters saved to {stats_file}")
-
-            nisarqa.copy_identification_group_to_stats_h5(
-                product=product, stats_h5=stats_h5
-            )
-            log.info(f"Input file Identification group copied to {stats_file}")
 
             # Save frequency/polarization info to stats file
             product.save_qa_metadata_to_h5(stats_h5=stats_h5)

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -518,16 +518,17 @@ class NisarProduct(ABC):
         runconfig_contents : str
             Contents (verbatim) of input granule's `runConfigurationContents`.
             If the product does not contain that Dataset (such as for older
-            datasets), "N/A" is returned.
+            granules), "N/A" is returned.
         """
 
-        path = Path(self._processing_info_metadata_group_path) / "parameters"
-        path = str(path)
+        path = (
+            self._processing_info_metadata_group_path +
+            "/parameters/runConfigurationContents"
+        )
         with h5py.File(self.filepath) as f:
-            if "runConfigurationContents" in f[path]:
-                runconfig = f[path]["runConfigurationContents"][...]
-                runconfig = nisarqa.byte_string_to_python_str(runconfig)
-                return runconfig
+            if path in f:
+                runconfig = f[path][...]
+                return nisarqa.byte_string_to_python_str(runconfig)
             else:
                 # Very old test datasets did not have this field.
                 # Discrepancies between this and the spec will be logged

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -522,8 +522,8 @@ class NisarProduct(ABC):
         """
 
         path = (
-            self._processing_info_metadata_group_path +
-            "/parameters/runConfigurationContents"
+            self._processing_info_metadata_group_path
+            + "/parameters/runConfigurationContents"
         )
         with h5py.File(self.filepath) as f:
             if path in f:

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -106,7 +106,7 @@ def _get_path_to_nearest_dataset(
     Parameters
     ----------
     h5_file : h5py.File
-        Handle to the input product h5 file.
+        Handle to the input product HDF5 file.
     starting_path : str
         Path to the starting dataset. This function will iterate up through
         each successive parent directory in `starting_path` to find the first
@@ -1551,7 +1551,7 @@ class NisarRadarProduct(NisarProduct):
         kwargs["ground_az_spacing"] = ground_az_spacing
 
         # Get Azimuth (y-axis) tick range + label
-        # path in h5 file: /science/LSAR/RSLC/swaths/zeroDopplerTime
+        # path in HDF5 file: /science/LSAR/RSLC/swaths/zeroDopplerTime
         # For NISAR, radar-domain grids are referenced by the center of the
         # pixel, so +/- half the distance of the pixel's side to capture
         # the entire range.
@@ -3506,7 +3506,7 @@ class InsarProduct(NisarProduct):
         Parameters
         ----------
         stats_h5 : h5py.File
-            Handle to an h5 file where the list(s) of polarizations
+            Handle to an HDF5 file where the list(s) of polarizations
             should be saved.
         """
         band = self.band

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -579,10 +579,9 @@ class NisarProduct(ABC):
             else:
                 if np.issubdtype(list_of_freqs.dtype, np.bytes_):
                     # list of byte strings. Yay!
-                    list_of_freqs = [
-                        nisarqa.byte_string_to_python_str(my_str)
-                        for my_str in list_of_freqs[()]
-                    ]
+                    list_of_freqs = nisarqa.byte_string_to_python_str(
+                        list_of_freqs[()]
+                    )
                 elif isinstance(list_of_freqs[0], bytes):
                     # list of Python bytes objects. Boo.
                     # This edge case occurs in some InSAR datasets, and should
@@ -652,10 +651,9 @@ class NisarProduct(ABC):
             else:
                 if np.issubdtype(list_of_pols.dtype, np.bytes_):
                     # list of byte strings. Yay!
-                    list_of_pols = [
-                        nisarqa.byte_string_to_python_str(my_str)
-                        for my_str in list_of_pols[()]
-                    ]
+                    list_of_pols = nisarqa.byte_string_to_python_str(
+                        list_of_pols[()]
+                    )
                 elif isinstance(list_of_pols[0], bytes):
                     # list of Python bytes objects. Boo.
                     # This edge case occurs in some InSAR datasets, and should
@@ -3318,10 +3316,7 @@ class GCOV(NonInsarGeoProduct):
                     " be a list of strings."
                 )
             else:
-                list_of_cov = [
-                    nisarqa.byte_string_to_python_str(my_str)
-                    for my_str in list_of_cov[()]
-                ]
+                list_of_cov = nisarqa.byte_string_to_python_str(list_of_cov[()])
 
             # Sanity check that the contents make sense
             # For GCOV, `get_possible_pols()` actually returns the

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -503,6 +503,42 @@ class NisarProduct(ABC):
             return spec_version
 
     @cached_property
+    def runconfig_contents(self) -> str:
+        """
+        Contents (verbatim) of input granule's `runConfigurationContents`.
+
+        Returns the Dataset contents as-is, with no further processing.
+        It is a known issue that the L1/L2 product types use different formats
+        for `runConfigurationContents` (e.g. JSON, YAML). If that format is
+        updated within ISCE3, then this function will simply continue to
+        copy the Dataset's contents as-is.
+
+        Returns
+        -------
+        runconfig_contents : str
+            Contents (verbatim) of input granule's `runConfigurationContents`.
+            If the product does not contain that Dataset (such as for older
+            datasets), "N/A" is returned.
+        """
+
+        path = Path(self._processing_info_metadata_group_path) / "parameters"
+        path = str(path)
+        with h5py.File(self.filepath) as f:
+            if "runConfigurationContents" in f[path]:
+                runconfig = f[path]["runConfigurationContents"][...]
+                runconfig = nisarqa.byte_string_to_python_str(runconfig)
+                return runconfig
+            else:
+                # Very old test datasets did not have this field.
+                # Discrepancies between this and the spec will be logged
+                # via the XML checker; no need to report again here.
+                nisarqa.get_logger().error(
+                    f"`runConfigurationContents` not found in input product"
+                    f" {path} Group. Defaulting to 'N/A'."
+                )
+                return "N/A"
+
+    @cached_property
     def list_of_frequencies(self) -> tuple[str, ...]:
         """
         The contents of .../identification/listOfFrequencies in input file.

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -520,7 +520,6 @@ class NisarProduct(ABC):
             If the product does not contain that Dataset (such as for older
             granules), "N/A" is returned.
         """
-
         path = (
             self._processing_info_metadata_group_path
             + "/parameters/runConfigurationContents"
@@ -535,7 +534,7 @@ class NisarProduct(ABC):
                 # via the XML checker; no need to report again here.
                 nisarqa.get_logger().error(
                     f"`runConfigurationContents` not found in input product"
-                    f" {path} Group. Defaulting to 'N/A'."
+                    f" at the path {path}. Defaulting to 'N/A'."
                 )
                 return "N/A"
 

--- a/src/nisarqa/products/rslc.py
+++ b/src/nisarqa/products/rslc.py
@@ -126,18 +126,10 @@ def verify_rslc(
         # workflow, so open in 'w' mode.
         # After this, always open STATS.h5 in 'r+' mode.
         with h5py.File(stats_file, mode="w") as stats_h5:
-            # Save the processing parameters to the stats.h5 file
-            # Note: If only the validate workflow is requested,
-            # this will do nothing.
-            root_params.save_processing_params_to_stats_h5(
-                h5_file=stats_h5, band=product.band
-            )
-            log.info(f"QA Processing Parameters saved to {stats_file}")
 
-            nisarqa.copy_identification_group_to_stats_h5(
-                product=product, stats_h5=stats_h5
+            nisarqa.setup_stats_h5_all_products(
+                product=product, stats_h5=stats_h5, root_params=root_params
             )
-            log.info(f"Input file Identification group copied to {stats_file}")
 
             nisarqa.copy_rfi_metadata_to_stats_h5(
                 product=product, stats_h5=stats_h5

--- a/src/nisarqa/products/rslc.py
+++ b/src/nisarqa/products/rslc.py
@@ -114,28 +114,6 @@ def verify_rslc(
         if not verbose:
             print(msg)
 
-    # If running these workflows, save the processing parameters and
-    # identification group to STATS.h5
-    if (
-        root_params.workflows.qa_reports
-        or root_params.workflows.abs_cal
-        or root_params.workflows.neb
-        or root_params.workflows.point_target
-    ):
-        # This is the first time opening the STATS.h5 file for RSLC
-        # workflow, so open in 'w' mode.
-        # After this, always open STATS.h5 in 'r+' mode.
-        with h5py.File(stats_file, mode="w") as stats_h5:
-
-            nisarqa.setup_stats_h5_all_products(
-                product=product, stats_h5=stats_h5, root_params=root_params
-            )
-
-            nisarqa.copy_rfi_metadata_to_stats_h5(
-                product=product, stats_h5=stats_h5
-            )
-            log.info(f"Input file RFI metadata copied to {stats_file}")
-
     # Both the `qa_reports` and/or `point_target` steps may generate a report
     # PDF. If both are workflows are enabled, this can cause an issue, since
     # closing and re-opening a `PdfPages` object causes the file to be
@@ -144,9 +122,34 @@ def verify_rslc(
     # steps. The file is automatically deleted upon closing if nothing was
     # written to it.
     with PdfPages(report_file, keep_empty=False) as report_pdf:
+        # If running these workflows, save the processing parameters and
+        # identification group to STATS.h5
+        if (
+            root_params.workflows.qa_reports
+            or root_params.workflows.abs_cal
+            or root_params.workflows.neb
+            or root_params.workflows.point_target
+        ):
+            # This is the first time opening the STATS.h5 file for RSLC
+            # workflow, so open in 'w' mode.
+            # After this, always open STATS.h5 in 'r+' mode.
+            with h5py.File(stats_file, mode="w") as stats_h5:
 
-        # Add file metadata and title page to report PDF.
-        nisarqa.setup_report_pdf(product=product, report_pdf=report_pdf)
+                nisarqa.setup_stats_h5_all_products(
+                    product=product, stats_h5=stats_h5, root_params=root_params
+                )
+
+                nisarqa.copy_rfi_metadata_to_stats_h5(
+                    product=product, stats_h5=stats_h5
+                )
+                log.info(f"Input file RFI metadata copied to {stats_file}")
+
+        if (
+            root_params.workflows.qa_reports
+            or root_params.workflows.point_target
+        ):
+            # Add file metadata and title page to report PDF.
+            nisarqa.setup_report_pdf(product=product, report_pdf=report_pdf)
 
         if root_params.workflows.qa_reports:
             log.info(f"Beginning `qa_reports` processing...")

--- a/src/nisarqa/utils/file_verification/checks.py
+++ b/src/nisarqa/utils/file_verification/checks.py
@@ -644,7 +644,7 @@ def compare_datetime_hdf5_to_xml(
         If the HDF5 Dataset is an array of byte strings, where at least
         one of those strings contains a datetime string.
         As of June 2025, NISAR product specs contain no Datasets like this;
-        handling these edge cases would cause unncessary code complexity.
+        handling these edge cases would cause unnecessary code complexity.
     """
     log = nisarqa.get_logger()
     flags = SingleAspectSingleInstanceFlags()
@@ -661,7 +661,7 @@ def compare_datetime_hdf5_to_xml(
 
     # Convert to a Python Unicode string. If Dataset is an array of byte
     # strings, this will return a list of Python strings.
-    # (Note: Arrays of byte strings also have a dtype of `numpy.bytes_``)
+    # (Note: Arrays of byte strings also have a dtype of `numpy.bytes_`)
     h5_ds_val = nisarqa.byte_string_to_python_str(h5_string)
 
     if isinstance(h5_ds_val, list):
@@ -670,7 +670,7 @@ def compare_datetime_hdf5_to_xml(
         # that are arrays of strings which should contain datetime strings.
         # Let's add a quick check in case this changes.
         for s in h5_ds_val:
-            if nisarqa.contains_datetime_value_substring(input_str=s):
+            if nisarqa.contains_datetime_value_substring(s):
                 raise NotImplementedError(
                     "Dataset contains an array of byte strings, in which"
                     " at least one byte string contains a datetime."

--- a/src/nisarqa/utils/file_verification/checks.py
+++ b/src/nisarqa/utils/file_verification/checks.py
@@ -658,7 +658,7 @@ def compare_datetime_hdf5_to_xml(
 
     # Now, check that the HDF5's corresponding Dataset is also a (byte) string.
     # If not, then the Dataset was incorrectly formed; however, another
-    # function in the XML Checker is is responsible for checking+logging that
+    # function in the XML Checker is responsible for checking+logging that
     # the HDF5 datatype must be np.bytes_ if the XML datatype is str,
     # so we do not need to log that issue again here. Instead, return early.
     # (Once the user fixes the dtype issue and reruns QA, then this datetime

--- a/src/nisarqa/utils/plotting.py
+++ b/src/nisarqa/utils/plotting.py
@@ -107,25 +107,14 @@ def add_title_page_to_report_pdf(
                 # granule ID is part of the title; do not repeat in the table
                 continue
 
-            # convert val to a string
+            # Read the value, then convert to its string representation
             v = val[()]
-            if np.issubdtype(v.dtype, np.bytes_):
-                if val.shape == ():
-                    # dataset is scalar, not a list
-                    v = nisarqa.byte_string_to_python_str(v)
-                else:
-                    # list of byte strings
-                    # Step 1: Format as a list that prints with commas
-                    v = [
-                        nisarqa.byte_string_to_python_str(my_str)
-                        for my_str in v
-                    ]
-                    # Step 2: Put into its string representation
-                    v = str(v)
 
-            else:
-                # numeric, etc dtype
-                v = str(v)
+            if np.issubdtype(v.dtype, np.bytes_):
+                # decode scalar byte strings and arrays of bytes strings
+                v = nisarqa.byte_string_to_python_str(v)
+
+            v = str(v)
 
             if len(v) > 30:
                 # Value is too long for a visually-appealing table.

--- a/src/nisarqa/utils/plotting.py
+++ b/src/nisarqa/utils/plotting.py
@@ -111,7 +111,7 @@ def add_title_page_to_report_pdf(
             v = val[()]
 
             if np.issubdtype(v.dtype, np.bytes_):
-                # decode scalar byte strings and arrays of bytes strings
+                # decode scalar byte strings and arrays of byte strings
                 v = nisarqa.byte_string_to_python_str(v)
 
             v = str(v)

--- a/src/nisarqa/utils/stats_h5_writer/setup_writer.py
+++ b/src/nisarqa/utils/stats_h5_writer/setup_writer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import h5py
 
 import nisarqa
+from nisarqa.utils.typing import RootParamGroupT
 
 objects_to_skip = nisarqa.get_all(name=__name__)
 
@@ -54,8 +55,8 @@ def copy_identification_group_to_stats_h5(
     product : nisarqa.NisarProduct
         Instance of a NisarProduct
     stats_h5 : h5py.File
-        Handle to an h5 file where the identification metadata
-        should be saved
+        Handle to an HDF5 file where the identification metadata
+        should be saved.
     """
 
     src_grp_path = product.identification_path
@@ -171,7 +172,7 @@ def save_nisar_freq_metadata_to_h5(
     product : nisarqa.NisarProduct
         Input NISAR product
     stats_h5 : h5py.File
-        Handle to an h5 file where the list(s) of polarizations should be saved
+        Handle to an HDF5 file where the list(s) of polarizations should be saved
     """
     # Populate data group's metadata
     for freq in product.freqs:

--- a/src/nisarqa/utils/stats_h5_writer/setup_writer.py
+++ b/src/nisarqa/utils/stats_h5_writer/setup_writer.py
@@ -172,7 +172,8 @@ def save_nisar_freq_metadata_to_h5(
     product : nisarqa.NisarProduct
         Input NISAR product
     stats_h5 : h5py.File
-        Handle to an HDF5 file where the list(s) of polarizations should be saved
+        Handle to an HDF5 file where the list(s) of polarizations
+        should be saved.
     """
     # Populate data group's metadata
     for freq in product.freqs:

--- a/src/nisarqa/utils/stats_h5_writer/setup_writer.py
+++ b/src/nisarqa/utils/stats_h5_writer/setup_writer.py
@@ -10,7 +10,7 @@ objects_to_skip = nisarqa.get_all(name=__name__)
 def setup_stats_h5_all_products(
     product: nisarqa.NisarProduct,
     stats_h5: h5py.File,
-    root_params: nisarqa.typing.RootParamGroupT,
+    root_params: RootParamGroupT,
 ) -> None:
     """
     Setup the STATS.h5 file for all NISAR products.
@@ -18,10 +18,9 @@ def setup_stats_h5_all_products(
     Parameters
     ----------
     product : nisarqa.NisarProduct
-        Instance of a NisarProduct.
+        The input product.
     stats_h5 : h5py.File
-        Handle to an h5 file where the identification metadata
-        should be saved.
+        Handle to the output HDF5 file.
     root_params : nisarqa.typing.RootParamGroupT
         *RootParamGroup object for the product type of `product`.
     """
@@ -89,18 +88,18 @@ def copy_src_runconfig_to_stats_h5(
     Parameters
     ----------
     product : nisarqa.NisarProduct
-        Instance of a NisarProduct.
+        The input product.
     stats_h5 : h5py.File
-        Handle to an h5 file where the source runconfig should be saved.
+        Handle to an HDF5 file where the source runconfig should be saved.
     """
 
-    grp_path = f"{nisarqa.STATS_H5_SOURCE_DATA % product.band}"
+    grp_path = nisarqa.STATS_H5_SOURCE_DATA % product.band
     contents = product.runconfig_contents
 
     nisarqa.create_dataset_in_h5group(
         h5_file=stats_h5,
         grp_path=grp_path,
-        ds_name=f"runConfigurationContents",
+        ds_name="runConfigurationContents",
         ds_data=contents,
         ds_description=(
             "Contents of the run configuration file associated with the"

--- a/src/nisarqa/utils/stats_h5_writer/setup_writer.py
+++ b/src/nisarqa/utils/stats_h5_writer/setup_writer.py
@@ -7,6 +7,42 @@ import nisarqa
 objects_to_skip = nisarqa.get_all(name=__name__)
 
 
+def setup_stats_h5_all_products(
+    product: nisarqa.NisarProduct,
+    stats_h5: h5py.File,
+    root_params: nisarqa.typing.RootParamGroupT,
+) -> None:
+    """
+    Setup the STATS.h5 file for all NISAR products.
+
+    Parameters
+    ----------
+    product : nisarqa.NisarProduct
+        Instance of a NisarProduct.
+    stats_h5 : h5py.File
+        Handle to an h5 file where the identification metadata
+        should be saved.
+    root_params : nisarqa.typing.RootParamGroupT
+        *RootParamGroup object for the product type of `product`.
+    """
+    log = nisarqa.get_logger()
+    stats_file = stats_h5.filename
+
+    # Save the processing parameters to the stats.h5 file
+    # Note: If only the validate workflow is requested,
+    # this will do nothing.
+    root_params.save_processing_params_to_stats_h5(
+        h5_file=stats_h5, band=product.band
+    )
+    log.info(f"QA Processing Parameters saved to {stats_file}")
+
+    copy_identification_group_to_stats_h5(product=product, stats_h5=stats_h5)
+    log.info(f"Input file Identification group copied to {stats_file}")
+
+    copy_src_runconfig_to_stats_h5(product=product, stats_h5=stats_h5)
+    log.info(f"Input file's runconfig copied to {stats_file}")
+
+
 def copy_identification_group_to_stats_h5(
     product: nisarqa.NisarProduct, stats_h5: h5py.File
 ) -> None:
@@ -36,6 +72,41 @@ def copy_identification_group_to_stats_h5(
         else:
             # Copy entire identification metadata from input file to stats.h5
             in_file.copy(in_file[src_grp_path], stats_h5, dest_grp_path)
+
+
+def copy_src_runconfig_to_stats_h5(
+    product: nisarqa.NisarProduct, stats_h5: h5py.File
+) -> None:
+    """
+    Copy input granule's `runConfigurationContents` Dataset to STATS.h5.
+
+    This copies the Dataset's contents as-is, with no further processing.
+    It is a known issue that the L1/L2 product types use different formats
+    for `runConfigurationContents` (e.g. JSON, YAML). If that format is
+    updated within ISCE3, then this function will simply continue to
+    copy the Dataset's contents as-is.
+
+    Parameters
+    ----------
+    product : nisarqa.NisarProduct
+        Instance of a NisarProduct.
+    stats_h5 : h5py.File
+        Handle to an h5 file where the source runconfig should be saved.
+    """
+
+    grp_path = f"{nisarqa.STATS_H5_SOURCE_DATA % product.band}"
+    contents = product.runconfig_contents
+
+    nisarqa.create_dataset_in_h5group(
+        h5_file=stats_h5,
+        grp_path=grp_path,
+        ds_name=f"runConfigurationContents",
+        ds_data=contents,
+        ds_description=(
+            "Contents of the run configuration file associated with the"
+            "processing of the source data"
+        ),
+    )
 
 
 def copy_rfi_metadata_to_stats_h5(

--- a/src/nisarqa/utils/stats_h5_writer/stats_h5_globals.py
+++ b/src/nisarqa/utils/stats_h5_writer/stats_h5_globals.py
@@ -17,6 +17,9 @@ STATS_H5_QA_FREQ_GROUP = (
     STATS_H5_QA_DATA_GROUP + "/frequency%s"
 )  # Two '%s' here!
 
+# Input Granule Source Data group (for copying Datasets verbatim)
+STATS_H5_SOURCE_DATA = STATS_H5_BASE_GROUP + "/sourceData"
+
 # RFI Group
 STATS_H5_RFI_BASE_GROUP = STATS_H5_BASE_GROUP + "/RFI"
 STATS_H5_RFI_DATA_GROUP = STATS_H5_RFI_BASE_GROUP + data_group
@@ -53,6 +56,7 @@ __all__ = [
     "STATS_H5_QA_PROCESSING_GROUP",
     "STATS_H5_QA_DATA_GROUP",
     "STATS_H5_QA_FREQ_GROUP",
+    "STATS_H5_SOURCE_DATA",
     "STATS_H5_RFI_BASE_GROUP",
     "STATS_H5_RFI_DATA_GROUP",
     "STATS_H5_ABSCAL_STATS_H5_BASE_GROUP",

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -364,7 +364,9 @@ def byte_string_to_python_str(byte_str):
         # array input
         return [str(s) for s in out]
     else:
-        raise ValueError(...)
+        raise ValueError(
+            f"{byte_str.ndim=}; N-dimensional (N>1) arrays are not supported."
+        )
 
 
 def get_logger() -> logging.Logger:

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -332,10 +332,10 @@ def byte_string_to_python_str(byte_str):
 
     Parameters
     ----------
-    byte_str : numpy.bytes_ or array-like of numpy.bytes_
+    byte_str : numpy.bytes_ or array_like of numpy.bytes_
         A byte string or 1D array of byte strings.
         If `byte_str` is a scalar byte string, it is converted to a Python string.
-        If `byte_str` is array-like of byte strings, it is converted
+        If `byte_str` is array_like of byte strings, it is converted
         element-wise to a Python strings and that are returned in a list.
 
     Returns
@@ -346,7 +346,7 @@ def byte_string_to_python_str(byte_str):
     Raises
     ------
     ValueError
-        If `byte_str` is a multi-dimensional array of byte strings.
+        If `byte_str` is an N-dimensional (N>1) array of byte strings.
         As of June 2025, NISAR products contain no Datasets like this;
         handling these edge cases would cause unnecessary code complexity.
     """

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -214,8 +214,8 @@ def create_dataset_in_h5group(
             isinstance(data, Sequence) and all(isinstance(s, str) for s in data)
         ):
             # If scalar byte string, numpy.char.encode() returns a
-            # scalar byte array.
-            # If array of byte strings, numpy.char.encode() returns a
+            # 0D array of byte strings.
+            # If a sequence of Python strings, numpy.char.encode() returns a
             # NumPy array of byte strings.
             # We want to use `np.char.encode()` to handle non-ASCII characters,
             # such as the copyright symbol.
@@ -322,7 +322,7 @@ def byte_string_to_python_str(byte_str: np.bytes_) -> str:
 
 
 @overload
-def byte_string_to_python_str(byte_str: ArrayLike[np.bytes_]) -> list[str]:
+def byte_string_to_python_str(byte_str: ArrayLike) -> list[str]:
     pass
 
 

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -210,12 +210,17 @@ def create_dataset_in_h5group(
     ) -> ArrayLike | np.bytes_:
         # If `data` is an e.g. numpy array with a numeric dtype,
         # do not alter it.
-        if isinstance(data, str):
-            data = np.bytes_(data)
-        elif isinstance(data, Sequence) and all(
-            isinstance(s, str) for s in data
+        if isinstance(data, str) or (
+            isinstance(data, Sequence) and all(isinstance(s, str) for s in data)
         ):
-            data = np.bytes_(data)
+            # If scalar byte string, numpy.char.encode() returns a
+            # scalar byte array.
+            # If array of byte strings, numpy.char.encode() returns a
+            # NumPy array of byte strings.
+            # We want to use `np.char.encode()` to handle non-ASCII characters,
+            # such as the copyright symbol.
+            # (`numpy.bytes_()` can only handle ASCII characters.)
+            data = np.char.encode(data, encoding="utf-8")
         elif isinstance(data, np.ndarray) and (
             np.issubdtype(data.dtype, np.object_)
             or np.issubdtype(data.dtype, np.str_)
@@ -311,16 +316,31 @@ def m2km(m):
     return m / 1000.0
 
 
+@overload
 def byte_string_to_python_str(byte_str: np.bytes_) -> str:
-    """Convert Numpy byte string to Python string object."""
-    # Step 1: Use .astype(np.str_) to cast from numpy byte string
-    # to numpy unicode (UTF-32)
-    out = byte_str.astype(np.str_)
+    pass
 
-    # Step 2: Use str(...) to cast from numpy string to normal python string
-    out = str(out)
 
-    return out
+@overload
+def byte_string_to_python_str(byte_str: ArrayLike[np.bytes_]) -> list[str]:
+    pass
+
+
+def byte_string_to_python_str(byte_str):
+    """Convert NumPy byte string(s) to Python string(s) (Unicode)."""
+    # Step 1: Decode from NumPy byte string to NumPy unicode (UTF-8)
+    # Unlike casting via `my_string.as_type(np.str_)`, this method also
+    # correctly decodes non-ASCII characters (such as the copyright symbol
+    # found in the runconfigs)
+    out = np.char.decode(byte_str, encoding="utf-8")
+
+    # Step 2: Use str(...) to cast from NumPy string to Python string (Unicode)
+    if out.shape == ():
+        # scalar input
+        return str(out)
+    else:
+        # array input
+        return [str(s) for s in out]
 
 
 def get_logger() -> logging.Logger:


### PR DESCRIPTION
Closes https://github.com/isce-framework/nisarqa/issues/30. This PR copies the input granule's `runConfigurationContents` Dataset's contents for all L1/L2 product types.

This Dataset is copied into a new Group called `sourceData`, like this:

![Screenshot 2025-06-05 at 4 22 36 PM](https://github.com/user-attachments/assets/6618a026-7ef7-48fe-868e-ba34b0bba4b4)

The name `sourceData` was chosen to stay in alignment with GSLC and GCOV, which nest copies of source data metadata under a similarly named Group. For example: `/science/LSAR/GCOV/metadata/sourceData/processingInformation/parameters/runConfigurationContents`

Because this is common functionality for all L1/L2, this PR takes the opportunity to refactor all of the `verify_*` functions, and collect all of these common setup functions under one new function called `setup_stats_h5_all_products()`.
