### PR TITLE
Copy `rfiLikelihood` for GSLC and GCOV

### DIFF
--- a/src/nisarqa/products/gcov.py
+++ b/src/nisarqa/products/gcov.py
@@ -138,20 +138,9 @@ def verify_gcov(
             # Add file metadata and title page to report PDF.
             nisarqa.setup_report_pdf(product=product, report_pdf=report_pdf)
 
-            nisarqa.setup_stats_h5_all_products(
+            nisarqa.setup_stats_h5_non_insar_products(
                 product=product, stats_h5=stats_h5, root_params=root_params
             )
-
-            # Save frequency/polarization info from `pols` to stats file
-            nisarqa.save_nisar_freq_metadata_to_h5(
-                product=product, stats_h5=stats_h5
-            )
-
-            # Copy imagery metrics into stats.h5
-            nisarqa.copy_non_insar_imagery_metrics(
-                product=product, stats_h5=stats_h5
-            )
-            log.info(f"Input file imagery metrics copied to {stats_file}")
 
             input_raster_represents_power = True
             name_of_backscatter_content = (

--- a/src/nisarqa/products/gslc.py
+++ b/src/nisarqa/products/gslc.py
@@ -121,7 +121,7 @@ def verify_gslc(
             # workflow, so open in 'w' mode.
             # After this, always open STATS.h5 in 'r+' mode.
             with h5py.File(stats_file, mode="w") as stats_h5:
-                nisarqa.setup_stats_h5_all_products(
+                nisarqa.setup_stats_h5_non_insar_products(
                     product=product, stats_h5=stats_h5, root_params=root_params
                 )
 
@@ -141,16 +141,6 @@ def verify_gslc(
             log.info(f"Browse image kml file saved to {browse_file_kml}")
 
             with h5py.File(stats_file, mode="r+") as stats_h5:
-
-                # Save frequency/polarization info to stats file
-                nisarqa.save_nisar_freq_metadata_to_h5(
-                    stats_h5=stats_h5, product=product
-                )
-
-                nisarqa.copy_non_insar_imagery_metrics(
-                    product=product, stats_h5=stats_h5
-                )
-                log.info(f"Input file imagery metrics copied to {stats_file}")
 
                 input_raster_represents_power = False
                 name_of_backscatter_content = (

--- a/src/nisarqa/products/product_reader.py
+++ b/src/nisarqa/products/product_reader.py
@@ -632,7 +632,7 @@ class NisarProduct(ABC):
         runconfig_contents : str
             Contents (verbatim) of input granule's `runConfigurationContents`.
             If the product does not contain that Dataset (such as for older
-            granules), "N/A" is returned.
+            datasets), "N/A" is returned.
         """
         path = (
             self._processing_info_metadata_group_path
@@ -647,7 +647,7 @@ class NisarProduct(ABC):
                 # Discrepancies between this and the spec will be logged
                 # via the XML checker; no need to report again here.
                 nisarqa.get_logger().error(
-                    f"`runConfigurationContents` not found in input product"
+                    "`runConfigurationContents` not found in input product"
                     f" at the path {path}. Defaulting to 'N/A'."
                 )
                 return "N/A"

--- a/src/nisarqa/products/rslc.py
+++ b/src/nisarqa/products/rslc.py
@@ -139,7 +139,7 @@ def verify_rslc(
             # After this, always open STATS.h5 in 'r+' mode.
             with h5py.File(stats_file, mode="w") as stats_h5:
 
-                nisarqa.setup_stats_h5_all_products(
+                nisarqa.setup_stats_h5_non_insar_products(
                     product=product, stats_h5=stats_h5, root_params=root_params
                 )
 
@@ -168,16 +168,6 @@ def verify_rslc(
             log.info(f"Browse image kml file saved to {browse_file_kml}")
 
             with h5py.File(stats_file, mode="r+") as stats_h5:
-                # Save frequency/polarization info to stats file
-                nisarqa.save_nisar_freq_metadata_to_h5(
-                    stats_h5=stats_h5, product=product
-                )
-
-                # Copy imagery metrics into stats.h5
-                nisarqa.copy_non_insar_imagery_metrics(
-                    product=product, stats_h5=stats_h5
-                )
-                log.info(f"Input file imagery metrics copied to {stats_file}")
 
                 input_raster_represents_power = False
                 name_of_backscatter_content = (


### PR DESCRIPTION
### Overview

Currently, `rfiLikelihood` is copied from the input granule to the output QA STATS.h5 file for only RSLC products. However, these `rfiLikelihood` datasets are also in the input GSLC and GCOV products. Based on offline conversations, it would be useful to users to copy this information for GSLC and GCOV as well. This PR implements that feature.


### Implementation

To implement this functionality, the following design choices were made:
* In the product reader, `get_rfi_likelihood_path()` was promoted from the child class `RSLC()` to a parent class `NonInsarProduct`. This allows GSLC and GCOV products to also have access to it. The docstring was updated accordingly.
* A new function `setup_stats_h5_non_insar_products()` was created, which first calls `setup_stats_h5_all_products()`, and then calls the additional setup functions used only by the Non-InSAR products.
    - This allows us to further refactor and reduce copy-paste in the RSLC, GSLC, and GCOV `verify_*` functions. In practice, the `save_nisar_freq_metadata_to_h5()` and `copy_non_insar_imagery_metrics()` functions can be moved from those three `verify_*` functions into one place: the new `setup_stats_h5_non_insar_products()` function.
