### PR TITLE
Bugfix for NumPy 2.0: Integer overflow for Connected Components labels

### DIFF
--- a/src/nisarqa/utils/plotting.py
+++ b/src/nisarqa/utils/plotting.py
@@ -3561,14 +3561,14 @@ def plot_connected_components_layer(
             " permissible interval for QA's plotting tools. Please update QA."
         )
     else:
-        labels_modified_dtype = labels.astype(np.int64)
+        labels_promoted = labels.astype(np.int64)
 
     # This assumes that `labels` is in sorted, ascending order.
     boundaries = np.concatenate(
         (
-            [labels_modified_dtype[0] - 1],
-            labels_modified_dtype[:-1] + np.diff(labels_modified_dtype) / 2.0,
-            [labels_modified_dtype[-1] + 1],
+            [labels_promoted[0] - 1],
+            labels_promoted[:-1] + np.diff(labels_promoted) / 2.0,
+            [labels_promoted[-1] + 1],
         )
     )
     norm = colors.BoundaryNorm(boundaries, len(boundaries) - 1)

--- a/src/nisarqa/utils/plotting.py
+++ b/src/nisarqa/utils/plotting.py
@@ -3539,7 +3539,7 @@ def plot_connected_components_layer(
     # dtype of unsigned int16 with a fill value of 65535. For the CC layer,
     # `0` designates pixels with invalid unwrapping, so `labels` will
     # typically be [0, ..., 65535].
-    # Because 0 and 65535 are the min and max values for uint32, when
+    # Because 0 and 65535 are the min and max values for uint16, when
     # we try to subtract 1 and add 1 to those values below when creating the
     # `boundaries` variable, we'll run into overflow errors.
     # Prior to NumPy 2.0 (e.g. NumPy 1.26), the datatype would automatically
@@ -3548,9 +3548,8 @@ def plot_connected_components_layer(
     # Sources:
     #     [1] https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion
     #     [2] https://numpy.org/neps/nep-0050-scalar-promotion.html
-    if (np.nanmin(labels) <= (-(2**63)) + 1) or (
-        np.nanmax(labels) >= (2**63 - 1) - 1
-    ):
+    info = np.iinfo(np.int64)
+    if (np.min(labels) <= info.min) or (np.max(labels) >= info.max):
         # The label values fall outside the permissible interval of NumPy's
         # int64, +/- 1 to account for the algorithm below.
         # This could happen if e.g. the CC layer has dtype uint64 and the


### PR DESCRIPTION
When creating the `boundaries` values to generate the discrete colorbar for the Connected Components plot, an integer overflow is occurring when using NumPy 2.0. This PR handles that bug.

h/t @gmgunter for identifying the underlying cause:
```
Yeah this changed in NumPy 2.0. It wasn't a bug in older NumPy versions -- the datatype would automatically be promoted to avoid overflow.
[1] https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion
[2] https://numpy.org/neps/nep-0050-scalar-promotion.html
```