### PR TITLE
Bugfix: `fmod` to modulo operator for wrapping

### DIFF
--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import math
 import os
 import shutil
 import tempfile
@@ -691,8 +690,14 @@ def wrap_to_interval(val, *, start, stop):
 
     is_scalar = not nisarqa.is_iterable(val)
     width = stop - start
-    wrap = lambda v: math.fmod(v - start, width) + start
 
+    # Python's `%` (modulo) operator computes the remainder with the same sign
+    # as the right-hand side operand, so the result of the modulo operation
+    # below is in the range [0, b-a), where b is the upper endpoint and a is
+    # the lower endpoint. Then, if we add a, the result will be in the
+    # range [a, b). See:
+    # https://docs.python.org/3/reference/expressions.html#binary-arithmetic-operations.
+    wrap = lambda v: (v - start) % width + start
     return wrap(val) if is_scalar else (wrap(v) for v in val)
 
 


### PR DESCRIPTION
As noted by @gmgunter , there is a bug when wrapping a value into an interval:

```python
>>> import nisarqa
>>> nisarqa.wrap_to_interval(-200.0, start=-180.0, stop=180.0)
-200.0
```

The [`math.fmod`](https://docs.python.org/3/library/math.html#math.fmod) function computes the remainder with the same side as the left-hand side operand, whereas Python's `%` (modulo) operator computes the remainder with the same sign as the right-hand side operand.

For our `wrap_to_interval()`, we want the result to be positive (see comment in the code), so we need to update the code to use Python's modulo operator.

This PR implements that change.