### PR TITLE
Remove 'Undefined' from options for `processingType` validation checks

### DIFF
--- a/src/nisarqa/validate/sanity_checks.py
+++ b/src/nisarqa/validate/sanity_checks.py
@@ -207,7 +207,14 @@ def identification_sanity_checks(
         data = _get_string_dataset(ds_name=ds_name)
         passes &= _verify_data_is_in_list(
             value=data,
-            valid_options=("Nominal", "Urgent", "Custom", "Undefined"),
+            # Only support "Nominal", "Urgent", and "Custom" values.
+            # As of product specs v1.3.0, "Undefined" was removed,
+            # so all products generated via nominal NISAR mission operations
+            # should not have "Undefined".
+            # Very few (if any) older test datasets used "Undefined", so it is
+            # not worth the added code complexity to handle older test datasets.
+            # Simply let it be logged as a false-negative.
+            valid_options=("Nominal", "Urgent", "Custom"),
             ds_name=ds_name,
         )
 


### PR DESCRIPTION
After discussion with NISAR ADT, "Undefined" was removed from the list of options for `processingType`. This PR reflects that change.

For reference, here are the updates in the PIX product specs and ISCE3:
 * (internal-only) https://github-fn.jpl.nasa.gov/NISAR-ADT/NISAR_PIX/pull/310
 * RSLC: "Undefined" was never implemented
 * Update in GSLC/GCOV: https://github.com/isce-framework/isce3/pull/59
 * Update in InSAR: https://github.com/isce-framework/isce3/pull/60