### PR TITLE
Bugfix: XML Checker - Account for UTM vs. polar stereo projections

### DIFF
--- a/src/nisarqa/validate/xml_spec_checker/policy.py
+++ b/src/nisarqa/validate/xml_spec_checker/policy.py
@@ -207,6 +207,91 @@ def ignored_xml_annotation_attributes() -> set[str]:
     return {"lang", "app"}
 
 
+def common_nisar_projection_attributes() -> set[str]:
+    """
+    Attributes common to NISAR "projection" Datasets but not required by CF-1.7.
+
+    These Attributes have been added to all "projection" Datasets by
+    NISAR convention. However, they are not required by CF-1.7 conventions
+    for either UTM or polar-stereographic projections.
+
+    Returns
+    -------
+    set[str]
+        The set of Attributes that are common to NISAR "projection" Datasets
+        but not required by CF-1.7 for UTM nor polar-steregraphic projections.
+    """
+    return {
+        "ellipsoid",
+        "epsg_code",
+        "longitude_of_projection_origin",
+        "spatial_ref",  # in the future, `spatial_ref` might update to `crs_wkt`
+    }
+
+
+def common_cf17_projection_attributes() -> set[str]:
+    """
+    CF-1.7 required Attributes common to UTM and polar-stereo "projection" Datasets.
+
+    These are per CF-1.7 Conventions:
+    https://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/apf.html
+
+    Returns
+    -------
+    set[str]
+        The set of CF-1.7 required Attributes common to all "projection" Datasets.
+    """
+    return {
+        "grid_mapping_name",
+        "false_easting",
+        "false_northing",
+        "semi_major_axis",
+        "inverse_flattening",
+        "latitude_of_projection_origin",
+    }
+
+
+def unique_cf17_utm_attributes() -> set[str]:
+    """
+    CF-1.7 required Attributes unique to UTM "projection" Datasets.
+
+    These are per CF-1.7 Conventions:
+    https://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/apf.html
+
+    Returns
+    -------
+    set[str]
+        The set of required Attributes unique to UTM "projection" Datasets.
+    """
+    return {
+        "utm_zone_number",
+        "scale_factor_at_central_meridian",
+        "longitude_of_central_meridian",
+    }
+
+
+def unique_cf17_polar_stereo_attributes() -> set[str]:
+    """
+    CF-1.7 required Attributes unique to polar stereo "projection" Datasets.
+
+    These are per CF-1.7 Conventions:
+    https://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/apf.html
+
+    Returns
+    -------
+    set[str]
+        The set of required Attributes unique to polar stereographic
+        "projection" Datasets.
+    """
+    return {
+        "straight_vertical_longitude_from_pole",
+        # CF-1.7 requires either "scale_factor_at_projection_origin" or
+        # "standard_parallel".
+        # ISCE3's outputs use "standard_parallel", so for now simply use that.
+        "standard_parallel",
+    }
+
+
 def numeric_dtype_should_not_have_units() -> set[str]:
     """
     Set of Dataset basenames that are numeric but should not have units.

--- a/src/nisarqa/validate/xml_spec_checker/xml_parser.py
+++ b/src/nisarqa/validate/xml_spec_checker/xml_parser.py
@@ -390,6 +390,28 @@ def element_to_annotation(
             f" 'io' are supported. XML Element: {dataset_name}"
         )
 
+    # Datasets named "projection" are required by CF-1.7 Conventions
+    # to contain specific Attributes, and different projections have different
+    # required Attributes. NISAR uses both UTM and polar stereographic
+    # projections. However, for simplicity, ADT decided that the XMLs
+    # should only contain the Attributes for UTM; the DOCX/PDF product specs
+    # would separately describe the polar stereo caveats.
+    # https://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/apf.html
+    # Here, ensure that the XML contains all necessary Attributes.
+    if dataset_name.endswith("/projection"):
+        req_attrs = (
+            nisarqa.common_nisar_projection_attributes()
+            | nisarqa.common_cf17_projection_attributes()
+            | nisarqa.unique_cf17_utm_attributes()
+        )
+        for name in req_attrs:
+            if name not in annotation_attribs:
+                log.error(
+                    f"{element.tag} annotation does not contain attribute"
+                    f" '{name}'. This attribute is required for Datasets"
+                    f" named 'projection' - XML Element {dataset_name}"
+                )
+
     return nisarqa.XMLAnnotation(
         attributes=annotation_attribs, description=description
     )


### PR DESCRIPTION
### Background

As noted by @vbrancat in on the internal repo (https://github-fn.jpl.nasa.gov/NISAR-ADT/NISAR_PIX/issues/242), georeferencing "projection" Datasets are required by CF-1.7 Conventions to contain specific Attributes. Different projections have different required Attributes, and there are some Attributes in common.

NISAR products use either UTM or polar stereographic projections, and each "projection" Dataset should contain the appropriate projection-specific parameters. For simplicity, ADT decided that the XMLs should only contain the Attributes for UTM, and then the corresponding DOCX/PDF product specification documentation would explain the polar-stereo Attributes separately.

### Current QA Status

Currently, the XML product specification documents and the QA XML Checker always assume granules are in UTM. This means that if a polar-stereo L2 product is QA'ed, then QA will incorrectly log several ERRORs.

### What this PR Accomplishes

The goals of this PR are:
* Quiet those false errors
* Robustly check for the presence of the correct projection-specific Attributes
* Checks that "projection" Datasets in the XML contain the necessary Attributes for UTM and NISAR conventions