### PR TITLE
Add EPSG Code to L2 plots; Make L2 axes labels generic

### DIFF
--- a/src/nisarqa/input_product_readers/geo_product.py
+++ b/src/nisarqa/input_product_readers/geo_product.py
@@ -229,6 +229,8 @@ class NisarGeoProduct(NisarProduct):
         kwargs["band"] = self.band
         kwargs["freq"] = "A" if "frequencyA" in raster_path else "B"
 
+        kwargs["epsg"] = self.epsg
+
         if parse_stats:
             kwargs["stats"] = _parse_dataset_stats_from_h5(
                 ds=h5_file[raster_path]

--- a/src/nisarqa/processing/setup_pdf.py
+++ b/src/nisarqa/processing/setup_pdf.py
@@ -94,6 +94,9 @@ def add_title_page_to_report_pdf(
 
         metadata["softwareVersion"] = product.software_version
 
+        if isinstance(product, nisarqa.NisarGeoProduct):
+            metadata["epsg"] = str(product.epsg)
+
         id_group = in_f[product.identification_path]
         for key, val in id_group.items():
             if key == "granuleId":

--- a/src/nisarqa/raster_classes.py
+++ b/src/nisarqa/raster_classes.py
@@ -481,7 +481,7 @@ class GeoRaster(SARRaster):
 
     @property
     def y_axis_label(self) -> str:
-        return "Northing (km)"
+        return "Y Coordinate (km)"
 
     @property
     def x_axis_spacing(self):
@@ -493,7 +493,7 @@ class GeoRaster(SARRaster):
 
     @property
     def x_axis_label(self) -> str:
-        return "Easting (km)"
+        return "X Coordinate (km)"
 
 
 @overload

--- a/src/nisarqa/raster_classes.py
+++ b/src/nisarqa/raster_classes.py
@@ -460,6 +460,8 @@ class GeoRaster(SARRaster):
     y_stop : float
         The stopping (South) Y position of the input array
         This corresponds to the lower side of the bottom pixels.
+    epsg : int
+        The EPSG code of the input raster.
     """
 
     # Attributes of the input array
@@ -471,6 +473,8 @@ class GeoRaster(SARRaster):
     y_start: float
     y_stop: float
 
+    epsg: int
+
     @property
     def y_axis_spacing(self):
         return self.y_spacing
@@ -481,7 +485,7 @@ class GeoRaster(SARRaster):
 
     @property
     def y_axis_label(self) -> str:
-        return "Y Coordinate (km)"
+        return f"Y Coordinate, EPSG:{self.epsg} (km)"
 
     @property
     def x_axis_spacing(self):
@@ -493,7 +497,7 @@ class GeoRaster(SARRaster):
 
     @property
     def x_axis_label(self) -> str:
-        return "X Coordinate (km)"
+        return f"X Coordinate, EPSG:{self.epsg} (km)"
 
 
 @overload


### PR DESCRIPTION
Closes #29 and #28 .

This PR:
 * Adds the ESPG code to the PDF cover page for all L2 products
 * Adds the EPSG code to the axes labels for all plots of L2 raster layers
 * Updates "Northing" and "Easting" plot labels to the generic "Y Coordinate" and "X Coordinate" labels. These are generic for any EPSG code.

Note: the implementation in this PR is a very simple way to ensure that 1) all L2 PDF reports are correctly and consistently labeled, and 2) that this code can be reviewed and merged in time for R5.

After R5, if we have more time and would like to refine the placement of the EPSG code in each of the individual plots, let's revisit this issue at that time.

Attached is a GCOV PDF output, and here are screenshots of that report:
<img width="705" height="429" alt="Screenshot 2025-08-13 at 12 23 57 PM" src="https://github.com/user-attachments/assets/71d2c980-09af-40f1-b2e1-e3dde9d99d48" />
<img width="661" height="574" alt="Screenshot 2025-08-13 at 12 24 07 PM" src="https://github.com/user-attachments/assets/5e6142f6-eba8-41aa-b49a-c4a848451428" />

[REPORT.pdf](https://github.com/user-attachments/files/21761025/REPORT.pdf)

