### PR TITLE
Bugfix: Copy `rfilikelihood` correctly for RSLC

### DIFF
--- a/src/nisarqa/processing/stats_h5_writer/setup_writer.py
+++ b/src/nisarqa/processing/stats_h5_writer/setup_writer.py
@@ -277,16 +277,26 @@ def copy_rfi_metadata_to_stats_h5(
                 )
                 try:
                     in_file.copy(src_path, stats_h5, dest_path)
-                except RuntimeError:
-                    # h5py.File.copy() raises this error if `src_path`
-                    # does not exist:
-                    #       RuntimeError: Unable to synchronously copy object
-                    #       (component not found)
-                    nisarqa.get_logger().error(
-                        "Cannot copy `rfiLikelihood`. Input granule is"
-                        " missing `rfiLikelihood` for"
-                        f" frequency {freq}, polarization {pol} at {src_path}"
-                    )
+                except RuntimeError as e:
+                    # h5py.File.copy() raises a RuntimeError with known
+                    # messages if `src_path` does not exist
+                    prefix = "Unable to synchronously copy object"
+                    known_errors = [
+                        f"{prefix} (object '{basename}' doesn't exist)",
+                        f"{prefix} (component not found)",
+                    ]
+                    if any((error in str(e) for error in known_errors)):
+                        nisarqa.get_logger().error(
+                            "Cannot copy `rfiLikelihood`. Input granule is"
+                            " missing `rfiLikelihood` for"
+                            f" frequency {freq}, polarization {pol} at {src_path}"
+                        )
+                        1 / 0
+                    else:
+                        # re-raise other RuntimeErrors, such as:
+                        #       RuntimeError: Unable to synchronously copy
+                        #       object (destination object already exists)
+                        raise
 
 
 def save_nisar_freq_metadata_to_h5(

--- a/src/nisarqa/processing/stats_h5_writer/setup_writer.py
+++ b/src/nisarqa/processing/stats_h5_writer/setup_writer.py
@@ -291,7 +291,6 @@ def copy_rfi_metadata_to_stats_h5(
                             " missing `rfiLikelihood` for"
                             f" frequency {freq}, polarization {pol} at {src_path}"
                         )
-                        1 / 0
                     else:
                         # re-raise other RuntimeErrors, such as:
                         #       RuntimeError: Unable to synchronously copy

--- a/src/nisarqa/workflows/rslc_qa.py
+++ b/src/nisarqa/workflows/rslc_qa.py
@@ -130,11 +130,6 @@ def rslc_qa(
                     product=product, stats_h5=stats_h5, root_params=root_params
                 )
 
-                nisarqa.copy_rfi_metadata_to_stats_h5(
-                    product=product, stats_h5=stats_h5
-                )
-                log.info(f"Input file RFI metadata copied to {stats_file}")
-
         if (
             root_params.workflows.qa_reports
             or root_params.workflows.point_target


### PR DESCRIPTION
Follow-on to #38, where there must have been a incorrectly-resolved merge conflict.

### Issue

In brief, QA is trying to copy the `rfiLikelihood` Datasets from the input RSLC HDF5 to the QA STATS HDF5 **twice**.

It is using `copy_rfi_metadata_to_stats_h5()` to copy `rfiLikelihood` inside these functions:
* `rslc_qa()`
* `setup_stats_h5_non_insar_products()` (which is called directly inside `rslc_qa()`)

This was not detected previously due to a `try..except` block treating all `RuntimeError` the same; this allowed the QA bug to be quietly logged in the log file.

### Fix

In this PR, we:
* Remove the redundant call to `copy_rfi_metadata_to_stats_h5()`
* Make the `try..except` specific to the error messages