### PR TITLE
Add'l `identification` Group sanity checks

### DIFF
--- a/src/nisarqa/utils/input_verification.py
+++ b/src/nisarqa/utils/input_verification.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Collection
 from typing import Any
 
 import h5py
@@ -826,6 +827,11 @@ def is_iterable(obj: Any) -> bool:
         return False
     else:
         return True
+
+
+def contains_duplicates(c: Collection) -> bool:
+    """True if input contains duplicate items. False o/w."""
+    return len(c) != len(set(c))
 
 
 __all__ = nisarqa.get_all(__name__, objects_to_skip)

--- a/src/nisarqa/validate/sanity_checks.py
+++ b/src/nisarqa/validate/sanity_checks.py
@@ -714,7 +714,6 @@ def _is_valid_nisar_doi(
 
     Notes
     -----
-    Source: https://wiki.jpl.nasa.gov/display/NISARSDS/Digital+Object+Identifiers+DOIs
     NISAR L1/L2 products follow the following conventions for DOI:
 
         10.5067/NI<level><product>-<maturity><version>
@@ -736,6 +735,7 @@ def _is_valid_nisar_doi(
     10.5067/NIL2GCOV-B1   NISAR_L2_GCOV_BETA_V1
     10.5067/NIL2GCOV-P1   NISAR_L2_GCOV_PROVISIONAL_V1
     10.5067/NIL2GCOV-V1   NISAR_L2_GCOV_V1
+    Source: https://wiki.jpl.nasa.gov/display/NISARSDS/Digital+Object+Identifiers+DOIs
     """
 
     # Build regex dynamically based on product types

--- a/src/nisarqa/validate/sanity_checks.py
+++ b/src/nisarqa/validate/sanity_checks.py
@@ -568,22 +568,18 @@ def _is_valid_observation_mode(obs_mode: list[str], path_in_h5: str) -> bool:
     140	L:QP:40N+05N:FS:B4:F05	US Agriculture, India Agriculture
     141	L:QP:20M+05N:FS:B4:F05	US Agriculture, India Agriculture Low Res
     """
-    # General regex breakdown:
-    #     ^L:                -> Must start with 'L:'
-    #     [A-Z]{2}           -> Two uppercase letters (mode code)
-    #     :                  -> Separator
-    #     (\d{2}[MNW])       -> Resolution, e.g. '20M', '05W', '40N'
-    #     \+                 -> Plus sign
-    #     (\d{2}[MNW]|---)   -> Second resolution or '---'
-    #     :FS:               -> Literal
-    #     B\d                -> e.g. 'B4'
-    #     :F\d{2}            -> e.g. 'F04'
-    #     $                  -> End of string
-    pattern = r"^L:[A-Z]{2}:(\d{2}[MNW])\+(\d{2}[MNW]|---):FS:B\d:F\d{2}$"
-
-    correct = (len(obs_mode) == 22) and (
-        re.fullmatch(pattern, obs_mode) is not None
+    pattern = (
+        r"^L:"  # Must start with 'L:'
+        r"[A-Z]{2}:"  # Two uppercase letters (mode code) and separator
+        r"(\d{2}[MNW])\+"  # Acq. Range Bandwidth Freq A and separator
+        r"(\d{2}[MNW]|---):"  # Acq. Range Bandwidth Freq B and separator
+        r"FS:"  # Literal
+        r"B\d:"  # Band(?)
+        r"F\d{2}"  # ???
+        r"$"  # End of string
     )
+
+    correct = re.fullmatch(pattern, obs_mode) is not None
 
     if not correct:
         nisarqa.get_logger().error(

--- a/src/nisarqa/validate/sanity_checks.py
+++ b/src/nisarqa/validate/sanity_checks.py
@@ -683,7 +683,7 @@ def _is_valid_observation_mode(obs_mode: list[str], path_in_h5: str) -> bool:
     if not correct:
         nisarqa.get_logger().error(
             f"Dataset contains value {obs_mode}, which does not match"
-            " a pattern like e.g. `L:QP:20M+05N:FS:B4:F05`."
+            " a pattern like e.g. `L:SCI:DH:40M+05N:FS:B4:D02`."
             f" Dataset: {path_in_h5}"
         )
 

--- a/src/nisarqa/validate/sanity_checks.py
+++ b/src/nisarqa/validate/sanity_checks.py
@@ -592,11 +592,11 @@ def _is_valid_observation_mode(obs_mode: list[str], path_in_h5: str) -> bool:
                  QQ (Quasi Quad)
                  QD (Quasi Dual HH/VV)
                  NO (Rx Only H, Rx Only V, or Qx Only HV)
-        <main> : Main Band's Range bandwidth. One of: 05, 40, 20, 77
+        <main> : Main band's range bandwidth. One of: 05, 40, 20, 77
         <pulse> : Pulse width of main band.
                   One of: N (Narrow), M (Medium), or W (Wide), or F (???)
                   Example: L:CAN:DH:77F+---:FS:B4:D01
-        <side> : Side Band's Range bandwidth.
+        <side> : Side band's range bandwidth.
                  One of: 05, 20, or -- (not acquired)
         <pulse> : Pulse width of side band
                   One of: N (Narrow), M (Medium), W (Wide), - (not acquired)
@@ -676,9 +676,9 @@ def _is_valid_observation_mode(obs_mode: list[str], path_in_h5: str) -> bool:
 
     # check against all three
     correct = (
-        l_band_pattern.match(obs_mode)
-        or s_band_pattern.match(obs_mode)
-        or joint_pattern.match(obs_mode)
+        l_band_pattern.match(obs_mode) is not None
+        or s_band_pattern.match(obs_mode) is not None
+        or joint_pattern.match(obs_mode) is not None
     )
     if not correct:
         nisarqa.get_logger().error(
@@ -745,7 +745,7 @@ def _is_valid_nisar_doi(
         rf"{product_type.upper()}"  # Product type
         rf"-"
         rf"(B|P|V)"  # Maturity
-        rf"([1-9])$"  # Version (1–9)
+        rf"[1-9]$"  # Version (1–9)
     )
 
     correct = re.fullmatch(pattern, doi) is not None

--- a/src/nisarqa/validate/sanity_checks.py
+++ b/src/nisarqa/validate/sanity_checks.py
@@ -498,7 +498,7 @@ def _is_valid_crid(crid: str, path_in_h5: str) -> bool:
         Example: P05000 for R05.00.0
 
     CRID convention for R4.0.8 or earlier:
-    
+
         ESMMmp
             Environment
                 A = ADT
@@ -575,7 +575,9 @@ def _is_valid_observation_mode(obs_mode: list[str], path_in_h5: str) -> bool:
     #     $                  -> End of string
     pattern = r"^L:[A-Z]{2}:(\d{2}[MNW])\+(\d{2}[MNW]|---):FS:B\d:F\d{2}$"
 
-    correct = (len(obs_mode) == 22) and (re.fullmatch(pattern, obs_mode) is not None)
+    correct = (len(obs_mode) == 22) and (
+        re.fullmatch(pattern, obs_mode) is not None
+    )
 
     if not correct:
         nisarqa.get_logger().error(

--- a/src/nisarqa/validate/sanity_checks.py
+++ b/src/nisarqa/validate/sanity_checks.py
@@ -513,12 +513,14 @@ def _is_valid_crid(crid: str, path_in_h5: str) -> bool:
                 P = Prod
                 S = Science Ondemand
             Spare has 1 numerical digit (was previously used to denote
-                0 = prelaunch, 1 = launch, but decided that it was unnessary
+                0 = prelaunch, 1 = launch, but decided that it was unnecessary
                 and was changed to spare)
             Major has 2 numerical digits
             minor has 1 numerical digits
             patch has 1 numerical digit
         Example: P00408 for R4.0.8
+
+    Source: https://wiki.jpl.nasa.gov/display/NISARSDS/CRID+release+notification+process
     """
     pattern = r"^[ADTPSEQ]\d{5}$"
     correct = re.fullmatch(pattern, crid) is not None

--- a/src/nisarqa/validate/sanity_checks.py
+++ b/src/nisarqa/validate/sanity_checks.py
@@ -240,7 +240,7 @@ def identification_sanity_checks(
                         " is from a different mission, e.g. ALOS or UAVSAR.)"
                         f" Dataset: {_full_path(ds_name)}"
                     )
-                passes &= data == "NISAR"
+                    passes = False
             else:
                 passes = False
 
@@ -284,6 +284,7 @@ def identification_sanity_checks(
                         f"Dataset is a scalar, but should be a list."
                         f" Dataset: {_full_path(ds_name)}"
                     )
+                    passes = False
                     data = [data]
                 for obs_mode in data:
                     passes &= _is_valid_observation_mode(
@@ -302,11 +303,11 @@ def identification_sanity_checks(
                     f"`{ds_name}` is the scalar {data!r}, but should be a list."
                     f" Dataset: {_full_path(ds_name)}"
                 )
-                passes &= False
+                passes = False
                 data = [data]
             if not set(data).issubset({"A", "B"}):
                 log.error(
-                    f"Dataset contains {{{data}}}, must be a subset of"
+                    f"Dataset contains {data}, must be a subset of"
                     f" {{'A', 'B'}}. Dataset: {_full_path(ds_name)}"
                 )
                 passes &= False
@@ -431,6 +432,7 @@ def identification_sanity_checks(
                     "['']",
                     "['' '' '' '' '']",
                     "None",
+                    "(NOT SPECIFIED)",
                 ):
                     log.error(
                         f"Dataset value is {data!r}, which is not a valid value."
@@ -495,7 +497,8 @@ def _is_valid_crid(crid: str, path_in_h5: str) -> bool:
             patch has 1 numerical digit
         Example: P05000 for R05.00.0
 
-        CRID convention for R4.0.8 or earlier
+    CRID convention for R4.0.8 or earlier:
+    
         ESMMmp
             Environment
                 A = ADT
@@ -512,7 +515,7 @@ def _is_valid_crid(crid: str, path_in_h5: str) -> bool:
         Example: P00408 for R4.0.8
     """
     pattern = r"^[ADTPSEQ]\d{5}$"
-    correct = bool(re.fullmatch(pattern, crid))
+    correct = re.fullmatch(pattern, crid) is not None
     if not correct:
         nisarqa.get_logger().error(
             f"Dataset value is {crid}, which does not match a pattern like"
@@ -572,7 +575,7 @@ def _is_valid_observation_mode(obs_mode: list[str], path_in_h5: str) -> bool:
     #     $                  -> End of string
     pattern = r"^L:[A-Z]{2}:(\d{2}[MNW])\+(\d{2}[MNW]|---):FS:B\d:F\d{2}$"
 
-    correct = len(obs_mode) == 22 and bool(re.fullmatch(pattern, obs_mode))
+    correct = (len(obs_mode) == 22) and (re.fullmatch(pattern, obs_mode) is not None)
 
     if not correct:
         nisarqa.get_logger().error(
@@ -617,7 +620,7 @@ def _is_valid_doi(doi: str, path_in_h5: str) -> bool:
     #     - Suffix: one or more non-space characters
 
     pattern = r"^10\.\d{4,9}/\S+$"
-    correct = bool(re.fullmatch(pattern, doi))
+    correct = re.fullmatch(pattern, doi) is not None
 
     if not correct:
         nisarqa.get_logger().error(

--- a/src/nisarqa/validate/sanity_checks.py
+++ b/src/nisarqa/validate/sanity_checks.py
@@ -70,7 +70,7 @@ def identification_sanity_checks(
             )
             return None
 
-    def _get_string_dataset(ds_name: str) -> str | None:
+    def _get_string_dataset(ds_name: str) -> str | list[str] | None:
         data = _get_dataset(ds_name=ds_name)
         if nisarqa.verify_str_meets_isce3_conventions(ds=id_group[ds_name]):
             return nisarqa.byte_string_to_python_str(data)

--- a/src/nisarqa/validate/sanity_checks.py
+++ b/src/nisarqa/validate/sanity_checks.py
@@ -273,8 +273,14 @@ def identification_sanity_checks(
         else:
             passes = False
 
-    if not product_type.lower() in nisarqa.LIST_OF_INSAR_PRODUCTS:
-        ds_name = "listOfObservationModes"
+    if product_type.lower() in nisarqa.LIST_OF_INSAR_PRODUCTS:
+        obs_modes = [
+            "referenceListOfObservationModes",
+            "secondaryListOfObservationModes",
+        ]
+    else:
+        obs_modes += ["listOfObservationModes"]
+    for ds_name in obs_modes:
         ds_checked.add(ds_name)
         if _dataset_exists(ds_name):
             data = _get_string_dataset(ds_name=ds_name)


### PR DESCRIPTION
This PR updates and adds "sanity checks" to confirm that Datasets in the `identification` Group are correctly formed. Previously, most of these were simply not checked, with a "warning" logged saying that they were not checked. Now, they have more-robust checking.

Updates include:
* `compositeReleaseId` -> New function to check the correct number of digits and pattern
* `missionId` and `platformName` must each be "NISAR"
* `processingCenter` should be "JPL" or "ISRO"
* `instrumentName` should be "L-SAR" or "S-SAR"
* `productDoi` must follow ISO conventions
* `listOfObservationModes` -> each mode must follow a specific format
    - Format determined per #57 
* `listOfFrequencies` must be a subset of {"A", "B"}

New Additions
* `plannedDatatakeId` and `plannedObservationId` are added for non-InSAR, and the reference and secondary counterparts are added for InSAR.
    - This reflects: https://github.com/isce-framework/isce3/pull/69

If any of these checks are premature to include in QA, I'm happy to remove and punt to a separate PR.

Thanks!
