### PR TITLE
Bugfix: cleanup for gcov rgb images

### DIFF
--- a/src/nisarqa/input_product_readers/gcov_reader.py
+++ b/src/nisarqa/input_product_readers/gcov_reader.py
@@ -316,13 +316,13 @@ class GCOV(NonInsarGeoProduct):
             )
 
             for gray_img in pol_imgs.values():
-                nisarqa.products.rslc.plot_to_grayscale_png(
+                nisarqa.plot_to_grayscale_png(
                     img_arr=gray_img, filepath=filepath
                 )
 
         else:
             # Output the RGB Browse Image
-            nisarqa.products.rslc.plot_to_rgb_png(
+            nisarqa.plot_to_rgb_png(
                 red=red, green=green, blue=blue, filepath=filepath
             )
 


### PR DESCRIPTION
This PR addresses a bug that was introduced in #50 , which is when we removed product-specific namespaces. The bug only appears for GCOV granules where multiple terms are combined to form an RGB browse image. (It does not appear for e.g. the NISAR sample products, which only contain single pol Freq A HHHH, which generate a greyscale browse image.)

These bugfixes were tested on a GCOV dataset generated using multiple polarizations in frequency A; this is the resulting RGB browse image:

<img width="1635" height="1787" alt="BROWSE" src="https://github.com/user-attachments/assets/3011ab80-c285-43bd-9bbe-cf5c8e3900f4" />
