### PR TITLE
Add sanity check for `staticLayersDataAccess`

### DIFF
--- a/src/nisarqa/validate/sanity_checks.py
+++ b/src/nisarqa/validate/sanity_checks.py
@@ -435,6 +435,9 @@ def identification_sanity_checks(
             "plannedObservationId",
         ]
 
+    if product_type.upper().startswith("G"):
+        misc_ds += ["staticLayersDataAccess"]
+
     for ds_name in misc_ds:
         ds_checked.add(ds_name)
         if _dataset_exists(ds_name):


### PR DESCRIPTION
The `staticLayersDataAccess` metadata for L2 products was moved to the `identification` Group in product specs v1.4.0. This PR reflects that change.