### PR TITLE
Allow RUNW/GUNW `ionospherePhaseScreen` raster to be all NaN

### DIFF
--- a/src/nisarqa/parameters/insar_params.py
+++ b/src/nisarqa/parameters/insar_params.py
@@ -771,29 +771,16 @@ class GUNWCohMagLayerParamGroup(Threshold99ParamGroup):
 
 
 @dataclass(frozen=True)
-class IonoPhaseScreenParamGroup(ZeroIsValidThresholdParamGroup):
+class IonoPhaseScreenParamGroupMixin:
     """
-    Parameters to ionosphere phase screen image in the report PDF.
+    Mixin for the ionosphere phase screen image in the report PDF.
 
     Parameters
     ----------
-    nan_threshold, inf_threshold, fill_threshold, near_zero_threshold,
-        total_invalid_threshold : float, optional
+    nan_threshold, fill_threshold, total_invalid_threshold : float, optional
         Threshold values for alerting users to possible malformed datasets.
         See `ThresholdParamGroup` docstring for complete description.
-        Default for Inf threshold:
-            `nisarqa.STATISTICS_THRESHOLD_PERCENTAGE`.
-        Default for NaN, fill, near-zero, and total invalid thresholds: -1.
-    epsilon : float, optional
-        Absolute tolerance for determining if a raster pixel is 'almost zero'.
-        Defaults to 1e-6.
-    zero_is_invalid: bool, optional
-        True if near-zero pixels should be counted towards the
-        total number of invalid pixels. False to exclude them.
-        If False, consider setting `near_zero_threshold` to -1.
-        Note: Fill values are always considered invalid. So, if a raster's
-        fill value is zero, then zeros will still be included in the total.
-        Defaults to False.
+        Default for NaN, fill, and total invalid thresholds: -1.
     """
 
     # The InSAR team decided that when the coherence is very low, then the
@@ -817,8 +804,14 @@ class IonoPhaseScreenParamGroup(ZeroIsValidThresholdParamGroup):
     )
 
 
+# The dataclass decorator adds fields in reverse MRO order.
+# So, inherit from the mixin first, in order to override the fields
+# from the second parent class.
+# Source: https://peps.python.org/pep-0557/#inheritance
 @dataclass(frozen=True)
-class RUNWIonoPhaseScreenParamGroup(IonoPhaseScreenParamGroup):
+class RUNWIonoPhaseScreenParamGroup(
+    IonoPhaseScreenParamGroupMixin, ZeroIsValidThresholdParamGroup
+):
     @staticmethod
     def get_path_to_group_in_runconfig():
         return [
@@ -831,8 +824,14 @@ class RUNWIonoPhaseScreenParamGroup(IonoPhaseScreenParamGroup):
         ]
 
 
+# The dataclass decorator adds fields in reverse MRO order.
+# So, inherit from the mixin first, in order to override the fields
+# from the second parent class.
+# Source: https://peps.python.org/pep-0557/#inheritance
 @dataclass(frozen=True)
-class GUNWIonoPhaseScreenParamGroup(IonoPhaseScreenParamGroup):
+class GUNWIonoPhaseScreenParamGroup(
+    IonoPhaseScreenParamGroupMixin, ZeroIsValidThreshold99ParamGroup
+):
     @staticmethod
     def get_path_to_group_in_runconfig():
         return [

--- a/src/nisarqa/parameters/insar_params.py
+++ b/src/nisarqa/parameters/insar_params.py
@@ -771,7 +771,54 @@ class GUNWCohMagLayerParamGroup(Threshold99ParamGroup):
 
 
 @dataclass(frozen=True)
-class RUNWIonoPhaseScreenParamGroup(ZeroIsValidThresholdParamGroup):
+class IonoPhaseScreenParamGroup(ZeroIsValidThresholdParamGroup):
+    """
+    Parameters to ionosphere phase screen image in the report PDF.
+
+    Parameters
+    ----------
+    nan_threshold, inf_threshold, fill_threshold, near_zero_threshold,
+        total_invalid_threshold : float, optional
+        Threshold values for alerting users to possible malformed datasets.
+        See `ThresholdParamGroup` docstring for complete description.
+        Default for Inf threshold:
+            `nisarqa.STATISTICS_THRESHOLD_PERCENTAGE`.
+        Default for NaN, fill, near-zero, and total invalid thresholds: -1.
+    epsilon : float, optional
+        Absolute tolerance for determining if a raster pixel is 'almost zero'.
+        Defaults to 1e-6.
+    zero_is_invalid: bool, optional
+        True if near-zero pixels should be counted towards the
+        total number of invalid pixels. False to exclude them.
+        If False, consider setting `near_zero_threshold` to -1.
+        Note: Fill values are always considered invalid. So, if a raster's
+        fill value is zero, then zeros will still be included in the total.
+        Defaults to False.
+    """
+
+    # The InSAR team decided that when the coherence is very low, then the
+    # InSAR workflow would set all pixels in the ionosphere phase screen layer
+    # to NaN. (Per the science team request, they did not set to zero
+    # because zero is a valid value.)
+    # So, default the relevant thresholds to -1 so that QA does not raise a
+    # fatal exception for that case.
+    nan_threshold: float = ThresholdParamGroup.get_field_with_updated_default(
+        param_name="nan_threshold", default=-1
+    )
+
+    fill_threshold: float = ThresholdParamGroup.get_field_with_updated_default(
+        param_name="fill_threshold", default=-1
+    )
+
+    total_invalid_threshold: float = (
+        ThresholdParamGroup.get_field_with_updated_default(
+            param_name="total_invalid_threshold", default=-1
+        )
+    )
+
+
+@dataclass(frozen=True)
+class RUNWIonoPhaseScreenParamGroup(IonoPhaseScreenParamGroup):
     @staticmethod
     def get_path_to_group_in_runconfig():
         return [
@@ -785,7 +832,7 @@ class RUNWIonoPhaseScreenParamGroup(ZeroIsValidThresholdParamGroup):
 
 
 @dataclass(frozen=True)
-class GUNWIonoPhaseScreenParamGroup(ZeroIsValidThreshold99ParamGroup):
+class GUNWIonoPhaseScreenParamGroup(IonoPhaseScreenParamGroup):
     @staticmethod
     def get_path_to_group_in_runconfig():
         return [

--- a/src/nisarqa/processing/insar/ionosphere_phase_screen.py
+++ b/src/nisarqa/processing/insar/ionosphere_phase_screen.py
@@ -68,19 +68,10 @@ def process_ionosphere_phase_screen(
                     params=params_iono_phs_uncert,
                 )
 
-                # -1 : user does not want to fail if raster is all-NaN
-                # 100 : user does not want to fail if raster is 100% NaN
-                iono_phs_thresh = params_iono_phs_screen.nan_threshold
-                fail_if_all_nan = not (
-                    np.isclose(iono_phs_thresh, 100.0, atol=1e-6, rtol=0.0)
-                    or np.isclose(iono_phs_thresh, -1, atol=1e-6, rtol=0.0)
-                )
-
                 plot_ionosphere_phase_screen_to_pdf(
                     iono_raster=iono_phs,
                     iono_uncertainty_raster=iono_uncertainty,
                     report_pdf=report_pdf,
-                    fail_if_all_nan=fail_if_all_nan,
                 )
 
                 # Plot Histograms
@@ -101,7 +92,6 @@ def plot_ionosphere_phase_screen_to_pdf(
     iono_raster: nisarqa.RadarRaster,
     iono_uncertainty_raster: nisarqa.RadarRaster,
     report_pdf: PdfPages,
-    fail_if_all_nan: bool,
 ) -> None: ...
 
 
@@ -110,7 +100,6 @@ def plot_ionosphere_phase_screen_to_pdf(
     iono_raster: nisarqa.GeoRaster,
     iono_uncertainty_raster: nisarqa.GeoRaster,
     report_pdf: PdfPages,
-    fail_if_all_nan: bool,
 ) -> None: ...
 
 
@@ -118,7 +107,6 @@ def plot_ionosphere_phase_screen_to_pdf(
     iono_raster,
     iono_uncertainty_raster,
     report_pdf,
-    fail_if_all_nan=True,
 ):
     """
     Create and append plots of ionosphere phase screen and uncertainty to PDF.
@@ -137,14 +125,6 @@ def plot_ionosphere_phase_screen_to_pdf(
         correspond to `iono_raster`.
     report_pdf : matplotlib.backends.backend_pdf.PdfPages
         The output PDF file to append the offsets plots to.
-    fail_if_all_nan : bool, optional
-        True if the ionosphere phase screen layer is not expected to
-        contain all NaN values. If True, and if that layer is all NaN,
-        then a ValueError will be raised.
-        False if it is expected that the ionosphere phase screen layer
-        may contain all NaN values, and it should still be plotted.
-        Note: this does not affect the handling of the ionosphere phase
-        screen uncertainty layer.
 
     Notes
     -----
@@ -190,8 +170,9 @@ def plot_ionosphere_phase_screen_to_pdf(
     iono_arr_min = np.nanmin(iono_arr)
     iono_arr_max = np.nanmax(iono_arr)
     if np.isnan(iono_arr_min) and np.isnan(iono_arr_max):
-        if fail_if_all_nan:
-            raise ValueError("`iono_raster.data` contains all NaN values.")
+        nisarqa.get_logger().warning(
+            "The ionosphere phase screen layer contains all NaN values."
+        )
     else:
         assert iono_arr_min >= (-np.pi - epsilon)
         assert iono_arr_max <= (np.pi + epsilon)


### PR DESCRIPTION
Per @oberonia78 , Based on the several discussions with InSAR team including @hfattahi , the `ionospherePhaseScreen` layer could be all NaN if there are no quality coherence values on the interferograms (e.g. the coherence is all very low).

To account for this expected case, this PR:
* Sets the RUNW and GUNW runconfig defaults to not fail if that layer is all-NaN values
* Updates the plotting code to not fail if that layer is all-NaN values

Note: Per @oberonia78 , `ionospherePhaseScreenUncentainty` will always have some values; we are only concerned with the `ionospherePhaseScreen`  in this update.

This PR was tested with both RUNW and GUNW products that have all-NaN values in the `ionospherePhaseScreen` layer.

cc: @vbrancat 


Comments:
1) With this PR, in the case of an all-NaN raster, QA will throw several new warning messages. Since they are not fatal, I suggest we raise an Issue in QA, and handle them after this release. Fortunately, the QA STATS HDF5 file is still generated and populated correctly to reflect raster's contents.

Here are the errors:
```
/Users/niemoell/Desktop/qa_public/nisarqa/src/nisarqa/processing/calc.py:336: RuntimeWarning: All-NaN slice encountered
  ds_data=func(arr_copy),
/Users/niemoell/Desktop/qa_public/nisarqa/src/nisarqa/processing/calc.py:336: RuntimeWarning: Mean of empty slice
  ds_data=func(arr_copy),
/Users/niemoell/miniforge3/envs/qa39/lib/python3.9/site-packages/numpy/lib/_nanfunctions_impl.py:2035: RuntimeWarning: Degrees of freedom <= 0 for slice.
  var = nanvar(a, axis=axis, dtype=dtype, out=out, ddof=ddof,
/Users/niemoell/Desktop/qa_public/nisarqa/src/nisarqa/processing/insar/ionosphere_phase_screen.py:190: RuntimeWarning: All-NaN slice encountered
  iono_arr_min = np.nanmin(iono_arr)
/Users/niemoell/Desktop/qa_public/nisarqa/src/nisarqa/processing/insar/ionosphere_phase_screen.py:191: RuntimeWarning: All-NaN slice encountered
  iono_arr_max = np.nanmax(iono_arr)
/Users/niemoell/miniforge3/envs/qa39/lib/python3.9/site-packages/numpy/lib/_histograms_impl.py:895: RuntimeWarning: invalid value encountered in divide
  return n/db/n.sum(), bin_edges
```


2) Because NaN values appear white in the PDF plots, it follows that the all-NaN ionosphere layer will appear as all-white. This could be confusing to users... but all of the layers in the PDF will look strange in these cases. For example, the coherence magnitude layer will be all black. (sample PDF report attached.)

<img width="1054" height="509" alt="Screenshot 2025-09-08 at 4 28 31 PM" src="https://github.com/user-attachments/assets/5527ab0c-f2d1-40db-8902-ae08feeccf5a" />


[REPORT.pdf](https://github.com/user-attachments/files/22223123/REPORT.pdf)
