### PR TITLE
Bugfix: Support NumPy 1.26.4

### DIFF
--- a/src/nisarqa/raster_classes.py
+++ b/src/nisarqa/raster_classes.py
@@ -924,7 +924,7 @@ def decimate_raster_array_to_square_pixels(
     """
     # Decimate to square pixels.
     return decimate_array_to_square_pixels(
-        arr=np.asarray(raster_obj.data, copy=True),
+        arr=np.array(raster_obj.data, copy=True),
         y_axis_spacing=raster_obj.y_axis_spacing,
         x_axis_spacing=raster_obj.x_axis_spacing,
     )
@@ -955,7 +955,7 @@ def decimate_raster_array_to_square_pixels_with_strides(
     """
     # Decimate to square pixels.
     return decimate_array_to_square_pixels_with_strides(
-        arr=np.asarray(raster_obj.data, copy=True),
+        arr=np.array(raster_obj.data, copy=True),
         y_axis_spacing=raster_obj.y_axis_spacing,
         x_axis_spacing=raster_obj.x_axis_spacing,
     )


### PR DESCRIPTION
For NumPy's `asarray()` function, the [`copy` parameter](https://numpy.org/doc/2.0/reference/generated/numpy.asarray.html#numpy-asarray) was added in NumPy 2.0.

Because ISCE3 builds with [NumPy 1.26.4](https://github.com/isce-framework/isce3/blob/ed73d7c48c8614e5a9ac836df95b999a535fb5d2/tools/imagesets/oracle8conda/runtime/spec-file.txt#L177), we need update QA to support this older NumPy version.