### PR TITLE
Tiny runConfigParameters dataset description changes

### DIFF
--- a/src/nisarqa/parameters/nisar_params.py
+++ b/src/nisarqa/parameters/nisar_params.py
@@ -1477,7 +1477,7 @@ class RootParamGroup(ABC):
             ds_data=self.get_final_user_runconfig(),
             ds_description=(
                 "Contents of the run configuration file with parameters used"
-                " for processing"
+                " for QA processing"
             ),
             ds_units=None,
         )

--- a/src/nisarqa/processing/stats_h5_writer/setup_writer.py
+++ b/src/nisarqa/processing/stats_h5_writer/setup_writer.py
@@ -236,7 +236,7 @@ def copy_src_runconfig_to_stats_h5(
         ds_data=contents,
         ds_description=(
             "Contents of the run configuration file associated with the"
-            "processing of the source data"
+            " processing of the source data"
         ),
     )
 


### PR DESCRIPTION
This small, low-priority PR does the following:
- Fixes a small typo in the description of the `science/*SAR/sourceData/runConfigurationContents` dataset
- Clarifies that the `science/*SAR/QA/processing/runConfigurationContents` dataset was used for QA processing.
  - While the path to this dataset could be used to infer its purpose, this small redundancy could clear up any residual confusion that a first-time viewer might encounter when looking over the file.