### PR TITLE
Bugfix: Add missing return values to `downsample_img_to_size_of_axes_with_stride()`

### DIFF
--- a/src/nisarqa/processing/plotting_utils.py
+++ b/src/nisarqa/processing/plotting_utils.py
@@ -296,7 +296,7 @@ def downsample_img_to_size_of_axes_with_stride(
 
         if src_arr_height <= desired_longest:
             # input array is smaller than window extent. No downsampling needed.
-            return arr
+            return arr, 1
 
         # Use floor division. (Better to have resolution that is *slightly*
         # better than the axes size, rather than the image being too small
@@ -310,7 +310,7 @@ def downsample_img_to_size_of_axes_with_stride(
 
         if src_arr_width <= desired_longest:
             # input array is smaller than window extent. No downsampling needed.
-            return arr
+            return arr, 1
 
         # Use floor division. See explanation above.)
         stride = int(src_arr_width / desired_longest)


### PR DESCRIPTION
This bug was introduced in #67. The function `downsample_img_to_size_of_axes_with_stride()` should return a pair of return values, but there are edge cases where only one value is returned. This PR addresses that issue.

### Impact without this PR

**During nominal NISAR operations, this bug should not be triggered.**

This PR is required if users:
1) manually create very small RSLC/GSLC/GCOV browse images (less than 370h x 497w pixels), or 
2) have tiny sample products (e.g. rasters smaller than 370h x 497w pixels).

#### Edge cases which trigger this bug:

1) (RSLC, GSLC, or GCOV): the user manually sets updates the runconfig to make a very small browse image, by either:
    a) set `longest_side_max` to a small number.
    - Because QA computes the number of looks dynamically based on the size of the input rasters and the X and Y spacings (in meters), there is not an exact "safe" value.
        - **The default value is 2048. Because 2048 >> 500, this edge case should not occur during nominal NISAR operations.**
        - Empirical testing shows that setting to 500 or 550 can still trigger the bug for certain datasets.
        **- _Setting `longest_side_max` to a minimum of 600 should be a safe rule-of-thumb to avoid this bug._**
    
    b) User sets `nlooks_freqa` or `nlooks_freqb` such that the resulting PNG image for either Freq A or Freq B are less than 370h x 497w pixels
    - **QA's default value is to not use these parameters, so this edge case will not occur during nominal NISAR operations.**
2) (all L1/L2 products): The source input rasters are tiny (less than e.g. 370h x 496w pixels.)
    - **Nominal NISAR products are all significantly larger by 1-2 orders of magnitude, so this edge case should not occur during nominal NISAR operations.**


Note: The source raster must be tiny in both height and width dimensions. For example, partial-frame L1 granules could have a very small number of pixels in height, but they will not trigger this edge case because the raster's width will still be much larger than ~500 pixels.
