### PR TITLE
Bugfix: Parse epoch correctly for L1 products

### DIFF
--- a/src/nisarqa/input_product_readers/radar_product.py
+++ b/src/nisarqa/input_product_readers/radar_product.py
@@ -206,15 +206,15 @@ class NisarRadarProduct(NisarProduct):
         )
         kwargs["zero_doppler_time"] = h5_file[path][...]
 
+        # Use zeroDopplerTime's units attribute to get the epoch.
+        kwargs["epoch"] = self._get_epoch(ds=h5_file[path])
+
         path = _get_path_to_nearest_dataset(
             h5_file=h5_file,
             starting_path=raster_path,
             dataset_to_find="zeroDopplerTimeSpacing",
         )
         kwargs["zero_doppler_time_spacing"] = h5_file[path][...]
-
-        # Use zeroDopplerTime's units attribute to get the epoch.
-        kwargs["epoch"] = self._get_epoch(ds=h5_file[path])
 
         # From the xml Product Spec, sceneCenterGroundRangeSpacing is the
         # 'Nominal ground range spacing in meters between consecutive pixels


### PR DESCRIPTION
This bug was introduced in #67 .

Without this fix, QA attempts to parse the epoch from `zeroDopplerTimeSpacing`, which results in the plots being labeled with an "INVALID EPOCH".
<img width="558" height="514" alt="Screenshot 2025-09-23 at 3 35 35 PM" src="https://github.com/user-attachments/assets/a8184b86-5af2-4f8a-8120-c42d312b1475" />

With this fix, QA labels the plots with the correct epoch:
<img width="525" height="513" alt="Screenshot 2025-09-23 at 3 36 11 PM" src="https://github.com/user-attachments/assets/7a2b882b-ff36-43a9-b813-372171794da9" />
