### PR TITLE
Add corner reflector LLH metadata to AbsCal & PTA outputs

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
     - cycler
     - h5py>=3
-    - isce3>=0.23
+    - isce3>=0.25
     - matplotlib
     - numpy>=1.20
     - pillow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 dependencies = [
     "cycler",
     "h5py>=3",
-    "isce3>=0.23",
+    "isce3>=0.25",
     "matplotlib",
     "numpy>=1.20",
     "pillow",

--- a/src/nisarqa/processing/caltools/abscal.py
+++ b/src/nisarqa/processing/caltools/abscal.py
@@ -195,7 +195,7 @@ def populate_abscal_hdf5_output(
         key="height_above_ellipsoid",
         ds_name="heightAboveEllipsoid",
         ds_descr=(
-            "The height of the corner reflector above the WGS 84 reference"
+            "The height of the corner reflector above the WGS84 reference"
             " ellipsoid at the time it was surveyed"
         ),
         ds_dtype=np.float64,

--- a/src/nisarqa/processing/caltools/abscal.py
+++ b/src/nisarqa/processing/caltools/abscal.py
@@ -171,6 +171,38 @@ def populate_abscal_hdf5_output(
     )
 
     create_dataset_from_abscal_results(
+        key="latitude_deg",
+        ds_name="latitude",
+        ds_descr=(
+            "The geodetic latitude of the corner reflector at the time it was"
+            " surveyed."
+        ),
+        ds_dtype=np.float64,
+        ds_units="degree_north",
+    )
+
+    create_dataset_from_abscal_results(
+        key="longitude_deg",
+        ds_name="longitude",
+        ds_descr=(
+            "The longitude of the corner reflector at the time it was surveyed."
+        ),
+        ds_dtype=np.float64,
+        ds_units="degree_east",
+    )
+
+    create_dataset_from_abscal_results(
+        key="height_above_ellipsoid",
+        ds_name="heightAboveEllipsoid",
+        ds_descr=(
+            "The height of the corner reflector above the WGS 84 reference"
+            " ellipsoid at the time it was surveyed"
+        ),
+        ds_dtype=np.float64,
+        ds_units="meters",
+    )
+
+    create_dataset_from_abscal_results(
         key="velocity",
         ds_name="cornerReflectorVelocity",
         ds_descr=(

--- a/src/nisarqa/processing/caltools/pta.py
+++ b/src/nisarqa/processing/caltools/pta.py
@@ -476,6 +476,38 @@ def populate_pta_hdf5_output(
     )
 
     create_dataset_from_pta_results(
+        key="latitude_deg",
+        ds_name="latitude",
+        ds_descr=(
+            "The geodetic latitude of the corner reflector at the time it was"
+            " surveyed"
+        ),
+        ds_dtype=np.float64,
+        ds_units="degree_north",
+    )
+
+    create_dataset_from_pta_results(
+        key="longitude_deg",
+        ds_name="longitude",
+        ds_descr=(
+            "The longitude of the corner reflector at the time it was surveyed"
+        ),
+        ds_dtype=np.float64,
+        ds_units="degree_east",
+    )
+
+    create_dataset_from_pta_results(
+        key="height_above_ellipsoid",
+        ds_name="heightAboveEllipsoid",
+        ds_descr=(
+            "The height of the corner reflector above the WGS 84 reference"
+            " ellipsoid at the time it was surveyed"
+        ),
+        ds_dtype=np.float64,
+        ds_units="meters",
+    )
+
+    create_dataset_from_pta_results(
         key="survey_date",
         grp_path=grp_path,
         ds_name="cornerReflectorSurveyDate",

--- a/src/nisarqa/processing/caltools/pta.py
+++ b/src/nisarqa/processing/caltools/pta.py
@@ -477,6 +477,7 @@ def populate_pta_hdf5_output(
 
     create_dataset_from_pta_results(
         key="latitude_deg",
+        grp_path=grp_path,
         ds_name="latitude",
         ds_descr=(
             "The geodetic latitude of the corner reflector at the time it was"
@@ -488,6 +489,7 @@ def populate_pta_hdf5_output(
 
     create_dataset_from_pta_results(
         key="longitude_deg",
+        grp_path=grp_path,
         ds_name="longitude",
         ds_descr=(
             "The longitude of the corner reflector at the time it was surveyed"
@@ -498,6 +500,7 @@ def populate_pta_hdf5_output(
 
     create_dataset_from_pta_results(
         key="height_above_ellipsoid",
+        grp_path=grp_path,
         ds_name="heightAboveEllipsoid",
         ds_descr=(
             "The height of the corner reflector above the WGS84 reference"

--- a/src/nisarqa/processing/caltools/pta.py
+++ b/src/nisarqa/processing/caltools/pta.py
@@ -500,7 +500,7 @@ def populate_pta_hdf5_output(
         key="height_above_ellipsoid",
         ds_name="heightAboveEllipsoid",
         ds_descr=(
-            "The height of the corner reflector above the WGS 84 reference"
+            "The height of the corner reflector above the WGS84 reference"
             " ellipsoid at the time it was surveyed"
         ),
         ds_dtype=np.float64,


### PR DESCRIPTION
Adds the corner reflector longitude, latitude, and height (at survey time) to the output of the AbsCal and PTA tools in the RSLC/GSLC QA STATS.h5 products.

This may be useful for apply post-processing corrections to the outputs of the PTA tool such as correcting for propagation delay due to atmospheric effects, for example.

This metadata was added to the output of the AbsCal and PTA tools in ISCE3 in https://github.com/isce-framework/isce3/pull/61, which was first released in ISCE3 [v0.25.0](https://github.com/isce-framework/isce3/releases/tag/v0.25.0), so this PR also bumps the minimum required ISCE3 version to 0.25.