### PR TITLE
Bugfix: Antimeridian crossing

### DIFF
--- a/src/nisarqa/lonlat.py
+++ b/src/nisarqa/lonlat.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import os
 import textwrap
-from collections.abc import Generator, Iterable, Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import numpy as np
+from numpy.typing import ArrayLike
 
 import nisarqa
 
@@ -37,26 +37,34 @@ def unwrap_longitudes(lons: Iterable[float]) -> list[float]:
         between any adjacent pair of longitude values is <= 180 degrees.
         The ordering of the points is preserved.
     """
-
     # since `lons` is an iterable, `wrap_to_interval` returns an iterator
     lons_180 = list(nisarqa.wrap_to_interval(val=lons, start=-180, stop=180))
 
-    unwrapped = [lons_180[0]]
+    return list(unwrap_degrees(angles=lons_180))
 
-    for prev_lon, curr_lon in nisarqa.pairwise(lons_180):
 
-        delta = curr_lon - prev_lon
+def unwrap_degrees(angles: ArrayLike) -> np.ndarray:
+    """
+    Unwrap a sequence of angles in degrees.
 
-        # If it's a large jump to the west, subtract 360
-        if delta > 180:
-            curr_lon -= 360
-        # If it's a large jump to the east, add 360
-        elif delta < -180:
-            curr_lon += 360
+    Unwraps the input angles such that the absolute differences between
+    adjacent elements are never greater than 180 degrees by adding a
+    multiple of 360 degrees to each element.
 
-        unwrapped.append(curr_lon)
+    Parameters
+    ----------
+    angles : array_like
+        The input sequence of angles, in degrees.
 
-    return unwrapped
+    Returns
+    -------
+    numpy.ndarray
+        The unwrapped angles, in degrees.
+    """
+    # `numpy.unwrap` doesn't correctly unwrap inputs in degrees prior
+    # to NumPy 1.21.0. See https://github.com/numpy/numpy/pull/16987.
+    # ISCE3 currently supports NumPy >=1.20.
+    return np.rad2deg(np.unwrap(np.deg2rad(angles)))
 
 
 def normalize_lon_lat_pts(lon_lat_points: Sequence[LonLat]) -> list[LonLat]:

--- a/src/nisarqa/lonlat.py
+++ b/src/nisarqa/lonlat.py
@@ -63,7 +63,7 @@ def unwrap_degrees(angles: ArrayLike) -> np.ndarray:
     """
     # `numpy.unwrap` doesn't correctly unwrap inputs in degrees prior
     # to NumPy 1.21.0. See https://github.com/numpy/numpy/pull/16987.
-    # ISCE3 currently supports NumPy >=1.20.
+    # nisarqa currently supports NumPy >=1.20.
     return np.rad2deg(np.unwrap(np.deg2rad(angles)))
 
 

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -701,35 +701,6 @@ def wrap_to_interval(val, *, start, stop):
     return wrap(val) if is_scalar else (wrap(v) for v in val)
 
 
-def pairwise(iterable: Iterable[T]) -> Generator[tuple[T, T], None, None]:
-    """
-    Return successive overlapping pairs taken from the input iterable.
-
-    Example: pairwise('ABCDEFG') -> AB BC CD DE EF FG
-
-    Source: https://docs.python.org/3/library/itertools.html#itertools.pairwise
-
-    Parameters
-    ----------
-    iterable : iterable of T
-        The input iterable.
-
-    Yields
-    ------
-    pair : pair of T
-        Successive overlapping pairs taken from the input iterable.
-        The number of 2-tuples in the output iterator will be one fewer than
-        the number of inputs. It will be empty if the input iterable has
-        fewer than two values.
-    """
-
-    iterator = iter(iterable)
-    a = next(iterator, None)
-    for b in iterator:
-        yield a, b
-        a = b
-
-
 @contextmanager
 def create_unique_subdirectory(
     parent_dir: str | os.PathLike | None = None,


### PR DESCRIPTION
### Issue

#27  introduced a bug into QA where certain frames over the antimeridian had their longitude values unwrapped incorrectly for the KML, resulting in outputs which plotted like this:

<img width="977" height="749" alt="Screenshot 2025-10-01 at 2 41 12 PM" src="https://github.com/user-attachments/assets/e4ab9102-40db-4aa3-a77a-625050bee73d" />

Looking at the longitude values in the KML screenshot, the unwrapping issue becomes obvious.

### Bugfix // Strategy

Original code snippet with bug, where the original `prev_lon` was being used as the reference for determining the `next_lon`, instead of using the updated `prev_lon`:

```python
    unwrapped = [lons_180[0]]
    for prev_lon, curr_lon in nisarqa.pairwise(lons_180):
        delta = curr_lon - prev_lon
        if delta > 180:
            curr_lon -= 360
        elif delta < -180:
            curr_lon += 360
        unwrapped.append(curr_lon)
    return unwrapped
```

Simple correction for that code snippet:

```python
    unwrapped = [lons_180[0]]
    prev_lon = lons_180[0]
    for curr_lon in lons_180[1:]:
        delta = curr_lon - prev_lon
        if delta > 180:
            curr_lon -= 360
        elif delta < -180:
            curr_lon += 360
        unwrapped.append(curr_lon)
        prev_lon = curr_lon
    return unwrapped
```

However, making this simple change does not account for if/when a polygon wraps around the globe multiple times.

So, @gmgunter suggested using an implementation similar to ISCE3's [`unwrap_degrees()`](https://github.com/isce-framework/isce3/blob/8cc6581525e608cc95fdcd883dac87e08f83e7d0/python/packages/isce3/geometry/bounding_polygon.py#L46-L67), which leverages NumPy's built-in unwrapping to correctly handle all cases.

This PR implements that change, resulting KMLs with correctly-unwrapped longitudes which plot nicely:


<img width="1008" height="701" alt="Screenshot 2025-10-01 at 2 57 59 PM" src="https://github.com/user-attachments/assets/4f3a8d70-95c6-4ffd-8e4b-cc0eb712e0a9" />
