### PR TITLE
Turn off caching for GSLC QA

### DIFF
--- a/src/nisarqa/parameters/gslc_params.py
+++ b/src/nisarqa/parameters/gslc_params.py
@@ -6,9 +6,9 @@ import nisarqa
 from .caltools_params import PointTargetAnalyzerParamGroup
 from .nisar_params import (
     InputFileGroupParamGroup,
+    NoCacheSoftwareConfigParamGroup,
     ProductPathGroupParamGroup,
     RootParamGroup,
-    SoftwareConfigParamGroup,
     ValidationGroupParamGroup,
     YamlAttrs,
 )
@@ -108,7 +108,7 @@ class GSLCRootParamGroup(RootParamGroup):
         Input File Group parameters for QA
     prodpath : ProductPathGroupParamGroup or None, optional
         Product Path Group parameters for QA
-    software_config : SoftwareConfigParamGroup or None, optional
+    software_config : NoCacheSoftwareConfigParamGroup or None, optional
         General QA Software Configuration Group parameters
     validation : ValidationGroupParamGroup or None, optional
         Validation Group parameters for QA
@@ -124,6 +124,7 @@ class GSLCRootParamGroup(RootParamGroup):
 
     # Overwrite parent's attributes b/c new type
     workflows: SLCWorkflowsParamGroup
+    software_config: NoCacheSoftwareConfigParamGroup
 
     # QA parameters
     backscatter_img: Optional[BackscatterImageParamGroup] = None
@@ -191,7 +192,7 @@ class GSLCRootParamGroup(RootParamGroup):
             Grp(
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="software_config",
-                param_grp_cls_obj=SoftwareConfigParamGroup,
+                param_grp_cls_obj=NoCacheSoftwareConfigParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -231,7 +232,7 @@ class GSLCRootParamGroup(RootParamGroup):
             "anc_files": GSLCDynamicAncillaryFileParamGroup,
             "prodpath": ProductPathGroupParamGroup,
             "workflows": SLCWorkflowsParamGroup,
-            "software_config": SoftwareConfigParamGroup,
+            "software_config": NoCacheSoftwareConfigParamGroup,
             "validation": ValidationGroupParamGroup,
             "backscatter_img": BackscatterImageParamGroup,
             "histogram": HistogramParamGroup,

--- a/src/nisarqa/parameters/nisar_params.py
+++ b/src/nisarqa/parameters/nisar_params.py
@@ -1155,6 +1155,30 @@ class SoftwareConfigParamGroup(YamlParamGroup):
 
 
 @dataclass(frozen=True)
+class NoCacheSoftwareConfigParamGroup(SoftwareConfigParamGroup):
+    """
+    Parameters from the Software Config Group runconfig group with cache off.
+
+    Parameters
+    ----------
+    use_cache : bool, optional
+        True to cache selected dataset(s) into intermediate
+        memory-mapped flat file(s), which speeds up repeat access.
+        False to always read data directly from the input file.
+        Generally, enabling caching should reduce runtime.
+        Defaults to False.
+    delete_scratch_files : bool, optional
+        True to delete the nested QA scratch directory and its contents
+        from inside `scratch_dir_parent` when QA SAS is finished.
+        Defaults to True.
+    """
+
+    use_cache: bool = SoftwareConfigParamGroup.get_field_with_updated_default(
+        param_name="use_cache", default=False
+    )
+
+
+@dataclass(frozen=True)
 class ValidationGroupParamGroup(YamlParamGroup):
     """
     Parameters from the Validation Group runconfig group.


### PR DESCRIPTION
Benchmarking after the R5 release showed a slowdown in GSLC QA for full-size datasets.

Further testing reproduced this slowdown, and confirmed that it was caused by the use of the cache. The testing also showed that for full-size GSLC dataset, when each layer was decompressed and stored as a memory-mapped temp file, each file is signficantly larger than the source GSLC HDF5. For example, a 20+5 DHDH GSLC HDF5 is 13GB but it decompressed to two ~20GB mem-mapped files for FreqA, two ~5GB mem-mapped files FreqB (~50GB total) on the scratch disk. 40+5 datasets would decompress to ~40GB per FreqA layer, etc.

Our sense is that the cost of re-reading and moving that large uncompressed data volume for each access by QA was greater than the time cost of re-reading and moving the smaller compressed layer and paying the decompression costs each time.

This PR turns off the caching for GSLC by default to improve runtime during operations, until we're able to investigate further and perhaps find a more-elegant solution.