### PR TITLE
Update `CUSTOM_CYCLER` to have 10 distinct line styles for plotting

### DIFF
--- a/src/nisarqa/globals.py
+++ b/src/nisarqa/globals.py
@@ -21,20 +21,24 @@ SEABORN_COLORBLIND = [
     (0.33725490196078434, 0.7058823529411765, 0.9137254901960784),
 ]
 CUSTOM_CYCLER = (
-    cycler(color=SEABORN_COLORBLIND[:6])
+    cycler(color=SEABORN_COLORBLIND[:10])
+    # repeat/mix line styles and widths to reach 10 unique combinations
     + cycler(
         linestyle=[
             "-",
             "-.",
             "--",
+            ":",
             (0, (3, 1, 1, 1)),
             (0, (3, 5, 1, 5, 1, 5)),
+            "-",
+            "-.",
+            "--",
             ":",
         ]
     )
-    + cycler(lw=np.linspace(3, 1, 6))
+    + cycler(lw=[1.5, 2.0, 2.5, 3.0, 1.5, 2.0, 2.5, 3.0, 2.0, 1.5])
 )
-
 
 #: The UTC time at which this module was first loaded, in ISO 8601 format with
 #: integer seconds precision.


### PR DESCRIPTION
This closes #150 

This update to `nisarqa`'s `CUSTOM_CYCLER` global impacts the QA PDF plots which use line styles for all eight L1/L2 products, although GCOV QA PDF reports are the only which need all 10 distinct line styles.

As an example output from this update, for quad pol GCOV products, the Freq A backscatter histograms will now be plotted with 10 distinct line styles like this:

<img width="679" height="514" alt="Screenshot 2026-01-22 at 2 11 12 PM" src="https://github.com/user-attachments/assets/3f2f169f-2d87-46ac-8c53-633aaea26b76" />

