### PR TITLE
Bugfix: Handle NFS silly rename issue when cleaning up scratch directory   

### DIFF
--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import logging
 import os
 import shutil
@@ -755,10 +756,46 @@ def create_unique_subdirectory(
     try:
         yield path
     finally:
-        log = nisarqa.get_logger()
         if delete:
+            log = nisarqa.get_logger()
+            # Use onerror callback to handle NFS "silly rename" behavior
+            # See: https://github.com/isce-framework/nisarqa/issues/152
+
+            # shutil.rmtree's onerror was deprecated in Python 3.12 and was
+            # planned to be removed in 3.14, but its deprecation was changed
+            # to docs only, with no pending removal version.
+            # See: https://github.com/python/cpython/pull/118947
+            def onerror(func, error_path, exc_info):
+                """Error handler for shutil.rmtree to handle NFS issues."""
+                exc_type, exc_value, exc_tb = exc_info
+
+                if issubclass(exc_type, FileNotFoundError):
+                    # File was already deleted (possibly by NFS), ignore
+                    pass
+                elif issubclass(exc_type, OSError):
+                    # Check if this is a "Directory not empty" error
+                    # This can occur on NFS due to "silly rename" (.nfsXXXXX files)
+                    if exc_value.errno in (errno.ENOTEMPTY, errno.EEXIST):
+                        # Log but don't raise - allow clean exit on NFS
+                        log.warning(
+                            f"nisarqa Could not delete '{error_path}': "
+                            f" {exc_value}. This may occur on Network File"
+                            " Systems where files are temporarily renamed"
+                            " before deletion."
+                        )
+                    else:
+                        # Some other OSError - raise it
+                        log.error(f"Error deleting '{error_path}': {exc_value}")
+                        raise
+                else:
+                    # Unexpected error type - raise it
+                    log.error(
+                        f"Unexpected error deleting '{error_path}': {exc_value}"
+                    )
+                    raise
+
             try:
-                shutil.rmtree(path)
+                shutil.rmtree(path, onerror=onerror)
             except FileNotFoundError:
                 msg = (
                     f"Created directory was '{path}', but it was"

--- a/src/nisarqa/utils/utils.py
+++ b/src/nisarqa/utils/utils.py
@@ -770,11 +770,20 @@ def create_unique_subdirectory(
                 exc_type, exc_value, exc_tb = exc_info
 
                 if issubclass(exc_type, FileNotFoundError):
-                    # File was already deleted (possibly by NFS), ignore
-                    pass
-                elif issubclass(exc_type, OSError):
-                    # Check if this is a "Directory not empty" error
-                    # This can occur on NFS due to "silly rename" (.nfsXXXXX files)
+                    # Directory was already deleted. Notify users because likely
+                    # they are violating a nisarqa design pattern; they
+                    # should fix their code to prevent tricky runtime bugs.
+                    msg = (
+                        f"Created directory was '{path}', but it was"
+                        " deleted external to (but within the context of)"
+                        " this context manager."
+                    )
+                    log.error(msg)
+                    raise FileNotFoundError(msg)
+
+                if issubclass(exc_type, OSError):
+                    # Check if this is a "Directory not empty" error. This can
+                    # occur on NFS due to "silly rename" (.nfsXXXXX files)
                     if exc_value.errno in (errno.ENOTEMPTY, errno.EEXIST):
                         # Log but don't raise - allow clean exit on NFS
                         log.warning(
@@ -794,18 +803,9 @@ def create_unique_subdirectory(
                     )
                     raise
 
-            try:
-                shutil.rmtree(path, onerror=onerror)
-            except FileNotFoundError:
-                msg = (
-                    f"Created directory was '{path}', but it was"
-                    " deleted external to (but within the context of)"
-                    " this context manager."
-                )
-                log.error(msg)
-                raise FileNotFoundError(msg)
-            else:
-                log.info(f"Directory deleted recursively: '{path}'")
+            # Delete directory. Exceptions will be handled via onerror.
+            shutil.rmtree(path, onerror=onerror)
+            log.info(f"Directory deleted recursively: '{path}'")
 
 
 def set_global_scratch_dir(scratch_dir: str | os.PathLike) -> None:


### PR DESCRIPTION
  ## Summary                                                                                                                  
  Fixes #152                                                                                                                  
                                                                                                                              
  This PR resolves the issue where `nisarqa` fails to exit cleanly when using Network File Systems (NFS) or the NISAR         
  On-Demand system (when the scratch directory is located in `/data`, which uses nfs4) due to the "NFS silly rename" behavior.                                                                    
                                                                                                                              
  ## Changes                                                                                                                  
  - Updated `create_unique_subdirectory()` context manager in `src/nisarqa/utils/utils.py` to use an `onerror` callback with `shutil.rmtree()`                                                                                                           
  - The callback gracefully handles:                                                                                          
    - `FileNotFoundError` : Same handling as the current implementation, which alert developers if fresh code violates the `nisarqa` design pattern by accidentally deleting the scratch directory outside of its context manager
    - `OSError` with `ENOTEMPTY`/`EEXIST`: Logs a warning but doesn't raise, allowing clean exit on NFS where files are temporarily renamed to `.nfsXXXXX` before deletion                                                                          
    - Other errors: Still raises as expected                                                                                  
                                                                                                                              
  ## Technical Details                                                                                                        
  The "NFS silly rename" behavior occurs when a file is unlinked while still open. NFS renames it to `.nfsXXXXX` temporarily instead of deleting immediately, which can cause "Directory not empty" errors during cleanup.                               
                                                                                                                              
  This implementation follows the pattern used in CPython's `tempfile.TemporaryDirectory` and uses `onerror` (rather than the newer `onexc` introduced in Python 3.12) for compatibility with `isce3` and `nisarqa`'s requirement of Python 3.9+     
                                                                                                                              
  ## Testing                                                                                                                  
  - The fix allows `nisarqa` to exit cleanly on NFS and NISAR On-Demand systems                                               
  - Local filesystem behavior remains unchanged                                                                               
  - Compatible with Python 3.9+                                                                                               
                                      